### PR TITLE
Send Go Router to the depth of hell where it belongs😑!!! (Deprecate Go Router use, Migrate app to Auto Route)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/android/app/.cxx/

--- a/lib/components/app_bar.dart
+++ b/lib/components/app_bar.dart
@@ -1,9 +1,10 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:circle/core/core.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 
 class CustomAppBar extends StatelessWidget {
   final String pageTitle;
@@ -36,7 +37,7 @@ class CustomAppBar extends StatelessWidget {
                 onPressed: () {
                   HapticFeedback.mediumImpact();
                   Feedback.forTap(context);
-                  context.pop();
+                  context.router.back();
                 },
                 icon: const Icon(FluentIcons.arrow_left_24_regular),
               ),

--- a/lib/components/app_button.dart
+++ b/lib/components/app_button.dart
@@ -88,7 +88,7 @@ class AppButton extends StatelessWidget {
         break;
 
       case ButtonType.outline:
-        labelColor = color ?? theme.colorScheme.primary;
+        labelColor = color ?? theme.colorScheme.onSurface;
 
         style = ElevatedButton.styleFrom(
           padding: EdgeInsets.symmetric(

--- a/lib/components/bottom_nav_bar.dart
+++ b/lib/components/bottom_nav_bar.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:auto_route/annotations.dart';
 import 'package:circle/core/theme/constants.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
@@ -12,8 +13,10 @@ import '../features/meds/meds.dart';
 import '../features/profile/profile.dart';
 import '../features/water/water.dart';
 
+@RoutePage(name: BottomNavBar.name)
 class BottomNavBar extends ConsumerStatefulWidget {
-  static const String id = "nav_bar";
+  static const String path = "/nav_bar";
+  static const String name = "BottomNavBar";
   const BottomNavBar({super.key});
 
   @override
@@ -28,19 +31,19 @@ class _BottomNavBarState extends ConsumerState<BottomNavBar> {
 
   final List<Widget> pages = [
     const HomeScreen(
-      key: PageStorageKey(HomeScreen.id),
+      key: PageStorageKey(HomeScreen .path),
     ),
     const WaterScreen(
-      key: PageStorageKey(WaterScreen.id),
+      key: PageStorageKey(WaterScreen .path),
     ),
     const EmergencyScreen(
-      key: PageStorageKey(EmergencyScreen.id),
+      key: PageStorageKey(EmergencyScreen .path),
     ),
     const MedsScreen(
-      key: PageStorageKey(MedsScreen.id),
+      key: PageStorageKey(MedsScreen .path),
     ),
     const ProfileScreen(
-      key: PageStorageKey(ProfileScreen.id),
+      key: PageStorageKey(ProfileScreen .path),
     ),
   ];
 

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -1,184 +1,90 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+import 'package:auto_route/auto_route.dart';
 import '../../components/bottom_nav_bar.dart';
 import '../../features/auth/auth.dart';
 import '../../features/emergency/emergency.dart';
 import '../../features/home/home.dart';
 import '../../features/meds/meds.dart';
 import '../../features/profile/profile.dart';
-import '../../features/water/screens/water_empty_screen.dart';
 import '../../features/water/water.dart';
+import 'routes.gr.dart' as route;
 
+@AutoRouterConfig()
+class AppRouter extends RootStackRouter {
+  @override
+  RouteType get defaultRouteType => const RouteType.adaptive();
 
-final routerProvider = Provider<GoRouter>((ref) {
-  return GoRouter(
-    initialLocation:  "/${LoadingScreen.id}",
-    routes: [
-      ///-------H
-      GoRoute(
-        path: "/",
-        name: BottomNavBar.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const BottomNavBar(),
-      ),
+  @override
+  List<AutoRoute> get routes => [
+    // ////-------Home-------//// //
+    AutoRoute(page: route.HomeScreen.page, path: HomeScreen.path),
 
-      GoRoute(
-        path: "/${LoadingScreen.id}",
-        name: LoadingScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const LoadingScreen(),
-      ),
+    // ////-------Water-------//// //
+    AutoRoute(page: route.WaterScreen.page, path: WaterScreen.path),
+    AutoRoute(
+      page: route.EditDailyGoalScreen.page,
+      path: EditDailyGoalScreen.path,
+    ),
+    AutoRoute(
+      page: route.SuggestedWaterDailyGoalScreen.page,
+      path: SuggestedWaterDailyGoalScreen.path,
+    ),
+    AutoRoute(page: route.WaterEmptyScreen.page, path: WaterEmptyScreen.path),
 
-      ///-------Home-------///
-      GoRoute(
-        path: "/${HomeScreen.id}",
-        name: HomeScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const HomeScreen(),
-      ),
+    // ////-------Emergency-------//// //
+    AutoRoute(page: route.EmergencyScreen.page, path: EmergencyScreen.path),
+    AutoRoute(
+      page: route.AddEmergencyContactScreen.page,
+      path: AddEmergencyContactScreen.path,
+    ),
+    AutoRoute(page: route.CrisisLogsScreen.page, path: CrisisLogsScreen.path),
 
-      ///------Water-------///
-      GoRoute(
-        path: "/${WaterScreen.id}",
-        name: WaterScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const WaterScreen(),
-        routes: <GoRoute>[
-          GoRoute(
-            path: EditDailyGoalScreen.id,
-            name: EditDailyGoalScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const EditDailyGoalScreen(),
-          ),
-          GoRoute(
-            path: SuggestedWaterDailyGoalScreen.id,
-            name: SuggestedWaterDailyGoalScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const SuggestedWaterDailyGoalScreen(),
-          ),
-          GoRoute(
-            path: WaterEmptyScreen.id,
-            name: WaterEmptyScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const WaterEmptyScreen(),
-          ),
-        ],
-      ),
+    // ////-------Profile-------///
+    AutoRoute(page: route.ProfileScreen.page, path: ProfileScreen.path),
+    AutoRoute(
+      page: route.ProfileBasicInfoScreen.page,
+      path: ProfileBasicInfoScreen.path,
+    ),
+    AutoRoute(
+      page: route.ProfileMedicalInfoScreen.page,
+      path: ProfileMedicalInfoScreen.path,
+    ),
+    AutoRoute(
+      page: route.ProfileVitalsInfoScreen.page,
+      path: ProfileVitalsInfoScreen.path,
+    ),
 
-      ///------Emergency-------///
-      GoRoute(
-        path: "/${EmergencyScreen.id}",
-        name: EmergencyScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const EmergencyScreen(),
-        routes: <GoRoute>[
-          GoRoute(
-            path: AddEmergencyContactScreen.id,
-            name: AddEmergencyContactScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const AddEmergencyContactScreen(),
-          ),
-          GoRoute(
-            path: CrisisLogsScreen.id,
-            name: CrisisLogsScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const CrisisLogsScreen(),
-          ),
-        ],
-      ),
+    // ////-------Medication-------//// //
+    AutoRoute(page: route.MedsScreen.page, path: MedsScreen.path),
+    AutoRoute(
+      page: route.MedsScheduleScreen.page,
+      path: MedsScheduleScreen.path,
+    ),
+    AutoRoute(page: route.AddMedsScreen.page, path: AddMedsScreen.path),
+    AutoRoute(page: route.MedsDetailsScreen.page, path: MedsDetailsScreen.path),
 
-      ///------Profile-------///
-      GoRoute(
-        path: "/${ProfileScreen.id}",
-        name: ProfileScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const ProfileScreen(),
-      ),
-      GoRoute(
-        path: "/${SettingsScreen.id}",
-        name: SettingsScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const SettingsScreen(),
-      ),
-      GoRoute(
-        path: "/${ProfileBasicInfoScreen.id}",
-        name: ProfileBasicInfoScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const ProfileBasicInfoScreen(),
-      ),
-      GoRoute(
-        path: "/${ProfileMedicalInfoScreen.id}",
-        name: ProfileMedicalInfoScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const ProfileMedicalInfoScreen(),
-      ),
-      GoRoute(
-        path: "/${ProfileVitalsInfoScreen.id}",
-        name: ProfileVitalsInfoScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const ProfileVitalsInfoScreen(),
-      ),
+    // ////-------Onboarding-------//// //
+    AutoRoute(
+      page: route.OnboardingBaseScreen.page,
+      path: OnboardingBaseScreen.path,
+    ),
 
-      ///------Medication-------///
-      GoRoute(
-        path: "/${MedsScreen.id}",
-        name: MedsScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const MedsScreen(),
-        routes: <GoRoute>[
-          GoRoute(
-            path: MedsScheduleScreen.id,
-            name: MedsScheduleScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const MedsScheduleScreen(),
-          ),
-          GoRoute(
-            path: AddMedsScreen.id,
-            name: AddMedsScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const AddMedsScreen(),
-          ),
-          GoRoute(
-            path: MedsDetailsScreen.id,
-            name: MedsDetailsScreen.id,
-            builder: (BuildContext context, GoRouterState state) =>
-                const MedsDetailsScreen(),
-          ),
-        ],
-      ),
+    // ////-------Auth-------//// //
+    AutoRoute(page: route.SignInScreen.page, path: SignInScreen.path),
+    AutoRoute(page: route.RegisterScreen.page, path: RegisterScreen.path),
+    AutoRoute(
+      page: route.GoogleSignInScreen.page,
+      path: GoogleSignInScreen.path,
+    ),
+    AutoRoute(page: route.AuthSuccessScreen.page, path: AuthSuccessScreen.path),
 
-      ///------ Onboarding Auth-------///
-      GoRoute(
-        path: "/auth/${SignInScreen.id}",
-        name: SignInScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const SignInScreen(),
-      ),
-      GoRoute(
-        path: "/auth/${RegisterScreen.id}",
-        name: RegisterScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const RegisterScreen(),
-      ),
-      GoRoute(
-        path: "/auth/${GoogleSignInScreen.id}",
-        name: GoogleSignInScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const GoogleSignInScreen(),
-      ),
-      GoRoute(
-        path: "/auth/${AuthSuccessScreen.id}",
-        name: AuthSuccessScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const AuthSuccessScreen(),
-      ),
-      GoRoute(
-        path: "/${OnboardingBaseScreen.id}",
-        name: OnboardingBaseScreen.id,
-        builder: (BuildContext context, GoRouterState state) =>
-            const OnboardingBaseScreen(),
-      ),
-    ],
-  );
-});
+    // ////-------Bottom Nav-------//// //
+    AutoRoute(page: route.BottomNavBar.page, path: BottomNavBar.path),
+
+    // ////-------Loading Screen-------//// //
+    AutoRoute(
+      page: route.LoadingScreen.page,
+      path: LoadingScreen.path,
+      initial: true,
+    ),
+  ];
+}

--- a/lib/core/routes/routes.gr.dart
+++ b/lib/core/routes/routes.gr.dart
@@ -1,0 +1,617 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// AutoRouterGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:auto_route/auto_route.dart' as _i25;
+import 'package:circle/components/bottom_nav_bar.dart' as _i4;
+import 'package:circle/features/auth/screens/auth/auth_success.dart' as _i3;
+import 'package:circle/features/auth/screens/auth/google_sign_in_screen.dart'
+    as _i8;
+import 'package:circle/features/auth/screens/auth/loading_screen.dart' as _i10;
+import 'package:circle/features/auth/screens/auth/register_screen.dart' as _i19;
+import 'package:circle/features/auth/screens/auth/sign_in_screen.dart' as _i21;
+import 'package:circle/features/auth/screens/onboarding/onboarding_base_screen.dart'
+    as _i14;
+import 'package:circle/features/emergency/screens/add_emergency_contact_screen.dart'
+    as _i1;
+import 'package:circle/features/emergency/screens/crisis_logs_screen.dart'
+    as _i5;
+import 'package:circle/features/emergency/screens/emergency_screen.dart' as _i7;
+import 'package:circle/features/home/screens/home_screen.dart' as _i9;
+import 'package:circle/features/meds/screens/add_edit_meds_screen.dart' as _i2;
+import 'package:circle/features/meds/screens/meds_details_screen.dart' as _i11;
+import 'package:circle/features/meds/screens/meds_schedule_screen.dart' as _i12;
+import 'package:circle/features/meds/screens/meds_screen.dart' as _i13;
+import 'package:circle/features/profile/screens/profile_basic_info_screen.dart'
+    as _i15;
+import 'package:circle/features/profile/screens/profile_medical_info_screen.dart'
+    as _i16;
+import 'package:circle/features/profile/screens/profile_screen.dart' as _i17;
+import 'package:circle/features/profile/screens/profile_vitals_info_screen.dart'
+    as _i18;
+import 'package:circle/features/profile/screens/settings_screen.dart' as _i20;
+import 'package:circle/features/water/screens/edit_daily_goal_screen.dart'
+    as _i6;
+import 'package:circle/features/water/screens/suggested_water_daily_goal_screen.dart'
+    as _i22;
+import 'package:circle/features/water/screens/water_empty_screen.dart' as _i23;
+import 'package:circle/features/water/screens/water_screen.dart' as _i24;
+import 'package:flutter/cupertino.dart' as _i26;
+import 'package:flutter/material.dart' as _i27;
+
+/// generated route for
+/// [_i1.AddEmergencyContactScreen]
+class AddEmergencyContactScreen extends _i25.PageRouteInfo<void> {
+  const AddEmergencyContactScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          AddEmergencyContactScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AddEmergencyContactScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i1.AddEmergencyContactScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i2.AddMedsScreen]
+class AddMedsScreen extends _i25.PageRouteInfo<AddMedsScreenArgs> {
+  AddMedsScreen({
+    _i26.Key? key,
+    bool isEditing = false,
+    List<_i25.PageRouteInfo>? children,
+  }) : super(
+          AddMedsScreen.name,
+          args: AddMedsScreenArgs(
+            key: key,
+            isEditing: isEditing,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'AddMedsScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<AddMedsScreenArgs>(
+          orElse: () => const AddMedsScreenArgs());
+      return _i2.AddMedsScreen(
+        key: args.key,
+        isEditing: args.isEditing,
+      );
+    },
+  );
+}
+
+class AddMedsScreenArgs {
+  const AddMedsScreenArgs({
+    this.key,
+    this.isEditing = false,
+  });
+
+  final _i26.Key? key;
+
+  final bool isEditing;
+
+  @override
+  String toString() {
+    return 'AddMedsScreenArgs{key: $key, isEditing: $isEditing}';
+  }
+}
+
+/// generated route for
+/// [_i3.AuthSuccessScreen]
+class AuthSuccessScreen extends _i25.PageRouteInfo<void> {
+  const AuthSuccessScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          AuthSuccessScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'AuthSuccessScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i3.AuthSuccessScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i4.BottomNavBar]
+class BottomNavBar extends _i25.PageRouteInfo<void> {
+  const BottomNavBar({List<_i25.PageRouteInfo>? children})
+      : super(
+          BottomNavBar.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'BottomNavBar';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i4.BottomNavBar();
+    },
+  );
+}
+
+/// generated route for
+/// [_i5.CrisisLogsScreen]
+class CrisisLogsScreen extends _i25.PageRouteInfo<void> {
+  const CrisisLogsScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          CrisisLogsScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'CrisisLogsScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i5.CrisisLogsScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i6.EditDailyGoalScreen]
+class EditDailyGoalScreen extends _i25.PageRouteInfo<void> {
+  const EditDailyGoalScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          EditDailyGoalScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'EditDailyGoalScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i6.EditDailyGoalScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i7.EmergencyScreen]
+class EmergencyScreen extends _i25.PageRouteInfo<void> {
+  const EmergencyScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          EmergencyScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'EmergencyScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i7.EmergencyScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i8.GoogleSignInScreen]
+class GoogleSignInScreen extends _i25.PageRouteInfo<void> {
+  const GoogleSignInScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          GoogleSignInScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'GoogleSignInScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i8.GoogleSignInScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i9.HomeScreen]
+class HomeScreen extends _i25.PageRouteInfo<void> {
+  const HomeScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          HomeScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'HomeScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i9.HomeScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i10.LoadingScreen]
+class LoadingScreen extends _i25.PageRouteInfo<void> {
+  const LoadingScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          LoadingScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'LoadingScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i10.LoadingScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i11.MedsDetailsScreen]
+class MedsDetailsScreen extends _i25.PageRouteInfo<void> {
+  const MedsDetailsScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          MedsDetailsScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'MedsDetailsScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i11.MedsDetailsScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i12.MedsScheduleScreen]
+class MedsScheduleScreen extends _i25.PageRouteInfo<void> {
+  const MedsScheduleScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          MedsScheduleScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'MedsScheduleScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i12.MedsScheduleScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i13.MedsScreen]
+class MedsScreen extends _i25.PageRouteInfo<void> {
+  const MedsScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          MedsScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'MedsScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i13.MedsScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i14.OnboardingBaseScreen]
+class OnboardingBaseScreen extends _i25.PageRouteInfo<void> {
+  const OnboardingBaseScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          OnboardingBaseScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'OnboardingBaseScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i14.OnboardingBaseScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i15.ProfileBasicInfoScreen]
+class ProfileBasicInfoScreen
+    extends _i25.PageRouteInfo<ProfileBasicInfoScreenArgs> {
+  ProfileBasicInfoScreen({
+    _i27.Key? key,
+    bool? isEditing = false,
+    List<_i25.PageRouteInfo>? children,
+  }) : super(
+          ProfileBasicInfoScreen.name,
+          args: ProfileBasicInfoScreenArgs(
+            key: key,
+            isEditing: isEditing,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ProfileBasicInfoScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<ProfileBasicInfoScreenArgs>(
+          orElse: () => const ProfileBasicInfoScreenArgs());
+      return _i15.ProfileBasicInfoScreen(
+        key: args.key,
+        isEditing: args.isEditing,
+      );
+    },
+  );
+}
+
+class ProfileBasicInfoScreenArgs {
+  const ProfileBasicInfoScreenArgs({
+    this.key,
+    this.isEditing = false,
+  });
+
+  final _i27.Key? key;
+
+  final bool? isEditing;
+
+  @override
+  String toString() {
+    return 'ProfileBasicInfoScreenArgs{key: $key, isEditing: $isEditing}';
+  }
+}
+
+/// generated route for
+/// [_i16.ProfileMedicalInfoScreen]
+class ProfileMedicalInfoScreen
+    extends _i25.PageRouteInfo<ProfileMedicalInfoScreenArgs> {
+  ProfileMedicalInfoScreen({
+    _i27.Key? key,
+    bool? isEditing = false,
+    List<_i25.PageRouteInfo>? children,
+  }) : super(
+          ProfileMedicalInfoScreen.name,
+          args: ProfileMedicalInfoScreenArgs(
+            key: key,
+            isEditing: isEditing,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ProfileMedicalInfoScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<ProfileMedicalInfoScreenArgs>(
+          orElse: () => const ProfileMedicalInfoScreenArgs());
+      return _i16.ProfileMedicalInfoScreen(
+        key: args.key,
+        isEditing: args.isEditing,
+      );
+    },
+  );
+}
+
+class ProfileMedicalInfoScreenArgs {
+  const ProfileMedicalInfoScreenArgs({
+    this.key,
+    this.isEditing = false,
+  });
+
+  final _i27.Key? key;
+
+  final bool? isEditing;
+
+  @override
+  String toString() {
+    return 'ProfileMedicalInfoScreenArgs{key: $key, isEditing: $isEditing}';
+  }
+}
+
+/// generated route for
+/// [_i17.ProfileScreen]
+class ProfileScreen extends _i25.PageRouteInfo<void> {
+  const ProfileScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          ProfileScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'ProfileScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i17.ProfileScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i18.ProfileVitalsInfoScreen]
+class ProfileVitalsInfoScreen
+    extends _i25.PageRouteInfo<ProfileVitalsInfoScreenArgs> {
+  ProfileVitalsInfoScreen({
+    _i27.Key? key,
+    bool? isEditing = false,
+    List<_i25.PageRouteInfo>? children,
+  }) : super(
+          ProfileVitalsInfoScreen.name,
+          args: ProfileVitalsInfoScreenArgs(
+            key: key,
+            isEditing: isEditing,
+          ),
+          initialChildren: children,
+        );
+
+  static const String name = 'ProfileVitalsInfoScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      final args = data.argsAs<ProfileVitalsInfoScreenArgs>(
+          orElse: () => const ProfileVitalsInfoScreenArgs());
+      return _i18.ProfileVitalsInfoScreen(
+        key: args.key,
+        isEditing: args.isEditing,
+      );
+    },
+  );
+}
+
+class ProfileVitalsInfoScreenArgs {
+  const ProfileVitalsInfoScreenArgs({
+    this.key,
+    this.isEditing = false,
+  });
+
+  final _i27.Key? key;
+
+  final bool? isEditing;
+
+  @override
+  String toString() {
+    return 'ProfileVitalsInfoScreenArgs{key: $key, isEditing: $isEditing}';
+  }
+}
+
+/// generated route for
+/// [_i19.RegisterScreen]
+class RegisterScreen extends _i25.PageRouteInfo<void> {
+  const RegisterScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          RegisterScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'RegisterScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i19.RegisterScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i20.SettingsScreen]
+class SettingsScreen extends _i25.PageRouteInfo<void> {
+  const SettingsScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          SettingsScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SettingsScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i20.SettingsScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i21.SignInScreen]
+class SignInScreen extends _i25.PageRouteInfo<void> {
+  const SignInScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          SignInScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SignInScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i21.SignInScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i22.SuggestedWaterDailyGoalScreen]
+class SuggestedWaterDailyGoalScreen extends _i25.PageRouteInfo<void> {
+  const SuggestedWaterDailyGoalScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          SuggestedWaterDailyGoalScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'SuggestedWaterDailyGoalScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i22.SuggestedWaterDailyGoalScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i23.WaterEmptyScreen]
+class WaterEmptyScreen extends _i25.PageRouteInfo<void> {
+  const WaterEmptyScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          WaterEmptyScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'WaterEmptyScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i23.WaterEmptyScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i24.WaterScreen]
+class WaterScreen extends _i25.PageRouteInfo<void> {
+  const WaterScreen({List<_i25.PageRouteInfo>? children})
+      : super(
+          WaterScreen.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'WaterScreen';
+
+  static _i25.PageInfo page = _i25.PageInfo(
+    name,
+    builder: (data) {
+      return const _i24.WaterScreen();
+    },
+  );
+}

--- a/lib/features/auth/screens/auth/auth_success.dart
+++ b/lib/features/auth/screens/auth/auth_success.dart
@@ -1,16 +1,18 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:springster/springster.dart';
 import '../../../../components/components.dart';
 import '../../../../core/core.dart';
 import '../../../profile/profile.dart';
 import '../../auth.dart';
-
+@RoutePage(name: AuthSuccessScreen.name)
 class AuthSuccessScreen extends ConsumerWidget {
-  static const id = "auth_success";
+  static const String path = "/auth_success";
+  static const String name = "AuthSuccessScreen";
   const AuthSuccessScreen({super.key});
 
   @override
@@ -103,7 +105,7 @@ class AuthSuccessScreen extends ConsumerWidget {
             const Spacer(),
             AppButton(
                   onPressed: () {
-                    context.goNamed(ProfileBasicInfoScreen.id);
+                    context.router.pushNamed(ProfileBasicInfoScreen.path);
                   },
                   label: "Continue",
                 )

--- a/lib/features/auth/screens/auth/google_sign_in_screen.dart
+++ b/lib/features/auth/screens/auth/google_sign_in_screen.dart
@@ -1,8 +1,9 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:hugeicons/hugeicons.dart';
 import 'package:springster/springster.dart';
 
@@ -12,9 +13,10 @@ import '../../../../core/core.dart';
 import '../../../../gen/assets.gen.dart';
 import '../../../profile/profile.dart';
 import '../../auth.dart';
-
+@RoutePage(name: GoogleSignInScreen.name)
 class GoogleSignInScreen extends ConsumerStatefulWidget {
-  static const String id = "google_sign_in";
+  static const String path = "/google_sign_in";
+  static const String name = "GoogleSignInScreen";
   const GoogleSignInScreen({super.key});
 
   @override
@@ -93,13 +95,13 @@ class _SignInScreenState extends ConsumerState<GoogleSignInScreen> {
                               updateRemote: true,
                             );
                             if (context.mounted) {
-                              context.goNamed(AuthSuccessScreen.id);
+                              context.router.pushNamed(AuthSuccessScreen.path);
                             }
                           } else {
                             if (userPreferences.isOnboarded) {
-                              context.goNamed(BottomNavBar.id);
+                              context.router.pushNamed(BottomNavBar.path);
                             } else {
-                              context.goNamed(ProfileBasicInfoScreen.id);
+                              context.router.pushNamed(ProfileBasicInfoScreen.path);
                             }
                           }
                         }
@@ -121,7 +123,7 @@ class _SignInScreenState extends ConsumerState<GoogleSignInScreen> {
             AppButton(
                   buttonType: ButtonType.outline,
                   onPressed: () {
-                    context.pushNamed(SignInScreen.id);
+                    context.router.pushNamed(SignInScreen.path);
                   },
                   color: theme.colorScheme.onSurface,
                   icon: HugeIcons.strokeRoundedMail01,

--- a/lib/features/auth/screens/auth/loading_screen.dart
+++ b/lib/features/auth/screens/auth/loading_screen.dart
@@ -1,14 +1,16 @@
 import 'dart:developer';
 
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import '../../../../components/bottom_nav_bar.dart';
-import '../../../profile/profile.dart';
 import '../../auth.dart';
+import 'package:circle/core/routes/routes.gr.dart' as route;
 
+
+@RoutePage(name: LoadingScreen.name)
 class LoadingScreen extends ConsumerStatefulWidget {
-  static const id = "loading_screen";
+  static const String name = "LoadingScreen";
+  static const String path = "/loading";
   const LoadingScreen({super.key});
 
   @override
@@ -51,20 +53,21 @@ class _LoadingScreenState extends ConsumerState<LoadingScreen> {
     final bool isOnboardingComplete = userPreferences.isOnboarded;
     final bool isLoggedIn = user.isNotEmpty;
     if (context.mounted) {
+      //Todo: Add logs to this page
       if (isLoggedIn) {
         if (!isOnboardingComplete) {
           ///not onboarded
-          context.goNamed(ProfileBasicInfoScreen.id);
+          context.router.popAndPush(route.ProfileBasicInfoScreen());
         } else {
           ///Logged in and onboarded
-          context.goNamed(BottomNavBar.id);
+          context.router.popAndPush(const route.BottomNavBar());
         }
       } else {
         ///Is not Logged In
         if (isFirstTime) {
-          context.goNamed(OnboardingBaseScreen.id);
+          context.router.popAndPush(const route.OnboardingBaseScreen());
         } else {
-          context.goNamed(GoogleSignInScreen.id);
+          context.router.popAndPush(const route.GoogleSignInScreen());
         }
       }
     }

--- a/lib/features/auth/screens/auth/register_screen.dart
+++ b/lib/features/auth/screens/auth/register_screen.dart
@@ -1,16 +1,18 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../../components/bottom_nav_bar.dart';
 import '../../../../components/components.dart';
 import '../../../../core/core.dart';
 import '../../../profile/profile.dart';
 import '../../auth.dart';
-
+@RoutePage(name: RegisterScreen.name)
 class RegisterScreen extends ConsumerStatefulWidget {
-  static const String id = "register";
+  static const String path = "/register";
+  static const String name = "RegisterScreen";
   const RegisterScreen({super.key});
 
   @override
@@ -213,14 +215,14 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                                       updateRemote: true,
                                     );
                                     if (context.mounted) {
-                                      context.goNamed(AuthSuccessScreen.id);
+                                      context.router.pushNamed(AuthSuccessScreen.path);
                                     }
                                   } else {
                                     if (userPreferences.isOnboarded) {
-                                      context.goNamed(BottomNavBar.id);
+                                      context.router.pushNamed(BottomNavBar.path);
                                     } else {
-                                      context.goNamed(
-                                        ProfileBasicInfoScreen.id,
+                                      context.router.pushNamed(
+                                        ProfileBasicInfoScreen.path,
                                       );
                                     }
                                   }
@@ -248,9 +250,9 @@ class _RegisterScreenState extends ConsumerState<RegisterScreen> {
                             isChipButton: true,
                             buttonType: ButtonType.text,
                             onPressed: () {
-                              // context.pushReplacementNamed(SignInScreen.id);
+                              // context.pushReplacementNamed(SignInScreen.path);
 
-                              context.goNamed(SignInScreen.id);
+                              context.router.pushNamed(SignInScreen.path);
 
                               // Navigator.push(context, MaterialPageRoute(builder: (context)=> const SignInScreen()));
                             },

--- a/lib/features/auth/screens/auth/sign_in_screen.dart
+++ b/lib/features/auth/screens/auth/sign_in_screen.dart
@@ -1,16 +1,19 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../../components/bottom_nav_bar.dart';
 import '../../../../components/components.dart';
 import '../../../../core/core.dart';
 import '../../../profile/profile.dart';
 import '../../auth.dart';
 
+@RoutePage(name: SignInScreen.name)
 class SignInScreen extends ConsumerStatefulWidget {
-  static const String id = "sign_in";
+  static const String path = "/sign_in";
+  static const String name = "SignInScreen";
   const SignInScreen({super.key});
 
   @override
@@ -156,13 +159,13 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
                                 updateRemote: true,
                               );
                               if (context.mounted) {
-                                context.goNamed(AuthSuccessScreen.id);
+                                context.router.pushNamed(AuthSuccessScreen.path);
                               }
                             } else {
                               if (userPreferences.isOnboarded) {
-                                context.goNamed(BottomNavBar.id);
+                                context.router.pushNamed(BottomNavBar.path);
                               } else {
-                                context.goNamed(ProfileBasicInfoScreen.id);
+                                context.router.pushNamed(ProfileBasicInfoScreen.path);
                               }
                             }
                           }
@@ -188,7 +191,7 @@ class _SignInScreenState extends ConsumerState<SignInScreen> {
                       isChipButton: true,
                       buttonType: ButtonType.text,
                       onPressed: () {
-                        context.goNamed(RegisterScreen.id);
+                        context.router.pushNamed(RegisterScreen.path);
                       },
                       label: "Create an Account",
                     ),

--- a/lib/features/auth/screens/onboarding/onboarding_base_screen.dart
+++ b/lib/features/auth/screens/onboarding/onboarding_base_screen.dart
@@ -1,12 +1,14 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:mesh_gradient/mesh_gradient.dart';
 
 import '../../auth.dart';
-
+@RoutePage(name: OnboardingBaseScreen.name)
 class OnboardingBaseScreen extends ConsumerStatefulWidget {
-  static const String id = "onboarding";
+  static const String path = "/onboarding";
+  static const String name = "OnboardingBaseScreen";
   const OnboardingBaseScreen({super.key});
 
   @override
@@ -157,7 +159,7 @@ class _OnboardingBaseScreenState extends ConsumerState<OnboardingBaseScreen> {
               }
               if (currentPageIndex == onboardingInfo.length - 1) {
                 //go to sign in
-                context.pushNamed(GoogleSignInScreen.id);
+                context.router.pushNamed(GoogleSignInScreen.path);
               }
             }),
           ),

--- a/lib/features/emergency/screens/add_emergency_contact_screen.dart
+++ b/lib/features/emergency/screens/add_emergency_contact_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
@@ -5,8 +6,10 @@ import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../../meds/meds.dart';
 
+@RoutePage(name: AddEmergencyContactScreen.name)
 class AddEmergencyContactScreen extends StatefulWidget {
-  static const String id = "add_emergency_contact";
+  static const String path = "/add_emergency_contact";
+  static const String name = "AddEmergencyContactScreen";
   const AddEmergencyContactScreen({super.key});
 
   @override

--- a/lib/features/emergency/screens/components/contact_card.dart
+++ b/lib/features/emergency/screens/components/contact_card.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
 
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../../components/components.dart';
 import '../../../../core/core.dart';
 import '../../emergency.dart';
@@ -57,7 +58,7 @@ class ContactCard extends StatelessWidget {
                     const Spacer(),
                     IconButton(
                         onPressed: () {
-                          context.pushNamed(AddEmergencyContactScreen.id);
+                          context.router.pushNamed(AddEmergencyContactScreen.path);
                         },
                         icon: const Icon(FluentIcons.edit_16_regular)),
                     IconButton(
@@ -81,7 +82,7 @@ class ContactCard extends StatelessWidget {
                                     AppButton(
                                       isChipButton: true,
                                       onPressed: () {
-                                        context.pop();
+                                        context.router.back();
                                       },
                                       label: "Cancel",
                                       buttonType: ButtonType.text,

--- a/lib/features/emergency/screens/components/dialogs/emergency_alert_no_contact_dialog.dart
+++ b/lib/features/emergency/screens/components/dialogs/emergency_alert_no_contact_dialog.dart
@@ -1,7 +1,8 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:circle/core/core.dart';
 
 import '../../../../../components/components.dart';
@@ -37,7 +38,7 @@ class EmergencyAlertNoContactDialog extends StatelessWidget {
           const Gap(16),
           AppButton(
             onPressed: () {
-              context.pushNamed(AddEmergencyContactScreen.id);
+              context.router.pushNamed(AddEmergencyContactScreen.path);
             },
             label: "Add a Contact",
             buttonType: ButtonType.primary,

--- a/lib/features/emergency/screens/crisis_logs_screen.dart
+++ b/lib/features/emergency/screens/crisis_logs_screen.dart
@@ -1,10 +1,12 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 
 import '../../../components/components.dart';
 import 'components/crisis_history_monthly.dart';
-
+@RoutePage(name: CrisisLogsScreen.name)
 class CrisisLogsScreen extends StatelessWidget {
-  static const String id = "crisis_logs";
+  static const String path = "/crisis_logs";
+  static const String name = "CrisisLogsScreen";
   const CrisisLogsScreen({super.key});
 
   @override

--- a/lib/features/emergency/screens/emergency_screen.dart
+++ b/lib/features/emergency/screens/emergency_screen.dart
@@ -1,13 +1,15 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:circle/core/core.dart';
 
 import '../../../components/components.dart';
 import '../emergency.dart';
-
+@RoutePage(name: EmergencyScreen.name)
 class EmergencyScreen extends StatelessWidget {
-  static const String id = "emergency";
+  static const String path = "/emergency";
+  static const String name = "EmergencyScreen";
   const EmergencyScreen({super.key});
 
   @override
@@ -62,7 +64,7 @@ class EmergencyScreen extends StatelessWidget {
                       const Gap(16),
                       ContactCard(
                         onPressed: () {
-                          context.goNamed(AddEmergencyContactScreen.id);
+                          context.router.pushNamed(AddEmergencyContactScreen.path);
                         },
                         showAddContactButton: true,
                       ),

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -1,7 +1,8 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../core/core.dart';
 import '../../auth/auth.dart';
 import '../../emergency/emergency.dart';
@@ -9,8 +10,10 @@ import '../../profile/profile.dart';
 import '../../water/water.dart';
 import '../home.dart';
 
+@RoutePage(name: HomeScreen.name)
 class HomeScreen extends ConsumerStatefulWidget {
-  static const String id = "home";
+  static const String path = "/home";
+  static const String name = "HomeScreen";
   const HomeScreen({super.key});
 
   @override
@@ -82,7 +85,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                     splashFactory: InkSparkle.splashFactory,
                     borderRadius: BorderRadius.circular(kPadding64),
                     onTap: () {
-                      context.pushNamed(ProfileScreen.id);
+                      context.router.pushNamed(ProfileScreen.path);
                     },
                     child: CircleAvatar(
                       backgroundImage: user.photoUrl != null
@@ -103,7 +106,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   percentageCompleted: percentComplete,
                   totalToday: totalToday.toInt(),
                   onPressed: () {
-                    context.pushNamed(WaterScreen.id);
+                    context.router.pushNamed(WaterScreen.path);
                   },
                   unit: Units.millilitres.symbol),
               const Gap(kPadding32),
@@ -115,13 +118,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               // const Gap(kPadding16),
               // GestureDetector(
               //     onTap: () {
-              //       context.goNamed(MedsScreen.id);
+              //       context.goNamed(MedsScreen.path);
               //     },
               //     child: const MedsReminderCard()),
               const Gap(kPadding16),
               EmergencySharingCard(
                 onPressed: () {
-                  context.pushNamed(EmergencyScreen.id);
+                  context.router.pushNamed(EmergencyScreen.path);
                 },
               ),
               const SizedBox(

--- a/lib/features/meds/screens/add_edit_meds_screen.dart
+++ b/lib/features/meds/screens/add_edit_meds_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 import 'dart:io';
 
+import 'package:auto_route/annotations.dart';
 import 'package:circle/core/extensions/date_time_formatter.dart';
 import 'package:circle/features/meds/models/dose.dart';
 import 'package:circle/features/meds/screens/components/dose_bottomsheet.dart';
@@ -23,8 +24,11 @@ import '../models/medication.dart';
 import '../providers/med_notifier.dart';
 
 ///Todo: Animate things on and off the screen more elegantly
+
+@RoutePage(name: AddMedsScreen.name)
 class AddMedsScreen extends ConsumerStatefulWidget {
-  static const String id = "add_meds";
+  static const String path = "/add_meds";
+  static const String name = "AddMedsScreen";
   final bool isEditing;
   const AddMedsScreen({super.key, this.isEditing = false});
 

--- a/lib/features/meds/screens/meds_details_screen.dart
+++ b/lib/features/meds/screens/meds_details_screen.dart
@@ -1,14 +1,17 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 
 import '../../../components/components.dart';
 import '../meds.dart';
 
+@RoutePage(name: MedsDetailsScreen.name)
 class MedsDetailsScreen extends StatelessWidget {
-  static const String id = "meds_details";
+  static const String path = "/meds_details";
+  static const String name = "MedsDetailsScreen";
   const MedsDetailsScreen({super.key});
 
   ///Todo: Add more medication detail here, like the does, frequency, and stuff, reference Apple Health
@@ -74,7 +77,7 @@ class MedsDetailsScreen extends StatelessWidget {
             const Gap(24),
             AppButton(
               onPressed: () {
-                context.pushNamed(AddMedsScreen.id);
+                context.router.pushNamed(AddMedsScreen.path);
               },
               label: "Edit Medication",
               icon: FluentIcons.edit_24_regular,

--- a/lib/features/meds/screens/meds_schedule_screen.dart
+++ b/lib/features/meds/screens/meds_schedule_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
@@ -7,8 +8,10 @@ import '../../../core/core.dart';
 import '../../profile/profile.dart';
 import '../meds.dart';
 
+@RoutePage(name: MedsScheduleScreen.name)
 class MedsScheduleScreen extends StatefulWidget {
-  static const String id = "meds_schedule";
+  static const String path = "/meds_schedule";
+  static const String name = "MedsScheduleScreen";
   const MedsScheduleScreen({super.key});
 
   @override

--- a/lib/features/meds/screens/meds_screen.dart
+++ b/lib/features/meds/screens/meds_screen.dart
@@ -1,15 +1,17 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../meds.dart';
 
-
+@RoutePage(name: MedsScreen.name)
 class MedsScreen extends StatelessWidget {
-  static const String id = "meds";
+  static const String path = "/meds";
+  static const String name = "MedsScreen";
   const MedsScreen({super.key});
 
   @override
@@ -48,7 +50,7 @@ class MedsScreen extends StatelessWidget {
                   AppButton(
                     icon: FluentIcons.add_24_regular,
                     onPressed: () {
-                      context.pushNamed(AddMedsScreen.id);
+                      context.router.pushNamed(AddMedsScreen.path);
                       // showAdaptiveDialog(
                       //   context: context,
                       //   builder: (context) => SicklerAlertDialog(

--- a/lib/features/profile/screens/profile_basic_info_screen.dart
+++ b/lib/features/profile/screens/profile_basic_info_screen.dart
@@ -1,14 +1,17 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../../auth/auth.dart';
 import '../profile.dart';
 
+@RoutePage(name: ProfileBasicInfoScreen.name)
 class ProfileBasicInfoScreen extends ConsumerStatefulWidget {
-  static const String id = "basic_info";
+  static const String path = "/basic_info";
+  static const String name = "ProfileBasicInfoScreen";
   final bool? isEditing;
 
   const ProfileBasicInfoScreen({super.key, this.isEditing = false});
@@ -226,7 +229,7 @@ class _ProfileBasicInfoScreenState
                               mode: SnackBarMode.error,
                             );
                           }else{
-                            context.pushNamed(ProfileVitalsInfoScreen.id);
+                            context.router.pushNamed(ProfileVitalsInfoScreen.path);
                           }
 
                         }

--- a/lib/features/profile/screens/profile_medical_info_screen.dart
+++ b/lib/features/profile/screens/profile_medical_info_screen.dart
@@ -1,16 +1,19 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../components/bottom_nav_bar.dart';
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../../auth/auth.dart';
 import '../../water/water.dart';
 
+@RoutePage(name: ProfileMedicalInfoScreen.name)
 class ProfileMedicalInfoScreen extends ConsumerStatefulWidget {
-  static const String id = "medical_info";
+  static const String path = "/medical_info";
+  static const String name = "ProfileMedicalInfoScreen";
   final bool? isEditing;
   const ProfileMedicalInfoScreen({super.key, this.isEditing = false});
 
@@ -82,7 +85,7 @@ class _ProfileMedicalInfoScreenState
                 AppButton(
                   isChipButton: true,
                   onPressed: () {
-                    context.goNamed(BottomNavBar.id);
+                    context.router.pushNamed(BottomNavBar.path);
                   },
                   label: "Skip",
                   buttonType: ButtonType.text,
@@ -218,7 +221,7 @@ class _ProfileMedicalInfoScreenState
                       message: "Profile Updated",
                       mode: SnackBarMode.success,
                     );
-                    context.pushNamed(SuggestedWaterDailyGoalScreen.id);
+                    context.router.pushNamed(SuggestedWaterDailyGoalScreen.path);
                   }
                 }
               },

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -1,17 +1,20 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:circle/features/auth/auth.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../../water/water.dart';
 import '../profile.dart';
 
+@RoutePage(name: ProfileScreen.name)
 class ProfileScreen extends ConsumerWidget {
-  static const String id = "profile";
+  static const String path = "/profile";
+  static const String name = "ProfileScreen";
   const ProfileScreen({super.key});
 
   @override
@@ -33,7 +36,7 @@ class ProfileScreen extends ConsumerWidget {
               const CustomAppBar(pageTitle: "Profile"),
               EditableAvatar(
                 onEditPressed: () {
-                  context.pushNamed(ProfileBasicInfoScreen.id);
+                  context.router.pushNamed(ProfileBasicInfoScreen.path);
                 },
                 imagePath: userProfile.photoUrl ?? "assets/images/memoji2.jpg",
               ),
@@ -113,7 +116,7 @@ class ProfileScreen extends ConsumerWidget {
                         const Spacer(),
                         IconButton(
                           onPressed: () {
-                            context.pushNamed(ProfileVitalsInfoScreen.id);
+                            context.router.pushNamed(ProfileVitalsInfoScreen.path);
                           },
                           icon: Icon(
                             FluentIcons.edit_24_regular,
@@ -128,7 +131,7 @@ class ProfileScreen extends ConsumerWidget {
                         Expanded(
                           child: VitalsItemCard(
                             onPressed: () {
-                              context.pushNamed(ProfileVitalsInfoScreen.id);
+                              context.router.pushNamed(ProfileVitalsInfoScreen.path);
                             },
                             label:
                                 "Height", //Todo:Create a store for height and weight logs.
@@ -160,7 +163,7 @@ class ProfileScreen extends ConsumerWidget {
                         Expanded(
                           child: VitalsItemCard(
                             onPressed: () {
-                              context.pushNamed(ProfileVitalsInfoScreen.id);
+                              context.router.pushNamed(ProfileVitalsInfoScreen.path);
                             },
                             label: "Weight",
                             value: userProfile.weight.toString(),
@@ -193,7 +196,7 @@ class ProfileScreen extends ConsumerWidget {
                         Expanded(
                           child: VitalsItemCard(
                             onPressed: () {
-                              context.pushNamed(WaterScreen.id);
+                              context.router.pushNamed(WaterScreen.path);
                             },
                             label: "Water",
                             value: "1200",

--- a/lib/features/profile/screens/profile_vitals_info_screen.dart
+++ b/lib/features/profile/screens/profile_vitals_info_screen.dart
@@ -1,17 +1,21 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
+
 
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 import '../../auth/auth.dart';
 import '../profile.dart';
 
+@RoutePage(name: ProfileVitalsInfoScreen.name)
 class ProfileVitalsInfoScreen extends ConsumerStatefulWidget {
-  static const String id = "vitals";
+  static const String path = "/vital_info";
+  static const String name = "ProfileVitalsInfoScreen";
+  
   final bool? isEditing;
   const ProfileVitalsInfoScreen({super.key, this.isEditing = false});
 
@@ -222,7 +226,7 @@ class _ProfileVitalsInfoScreenState
                                 mode: SnackBarMode.error,
                               );
                             } else {
-                              context.pushNamed(ProfileMedicalInfoScreen.id);
+                              context.router.pushNamed(ProfileMedicalInfoScreen.path);
                             }
                           }
                         }

--- a/lib/features/profile/screens/settings_screen.dart
+++ b/lib/features/profile/screens/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
@@ -5,8 +6,10 @@ import 'package:gap/gap.dart';
 import '../../../components/components.dart';
 import '../profile.dart';
 
+@RoutePage(name: SettingsScreen.name)
 class SettingsScreen extends StatelessWidget {
-  static const String id = "settings";
+  static const String path = "/settings";
+  static const String name = "SettingsScreen";
   const SettingsScreen({super.key});
 
   @override

--- a/lib/features/water/screens/edit_daily_goal_screen.dart
+++ b/lib/features/water/screens/edit_daily_goal_screen.dart
@@ -1,11 +1,14 @@
+import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
 import '../../../components/components.dart';
 import '../../../core/core.dart';
 
+@RoutePage(name: EditDailyGoalScreen.name)
 class EditDailyGoalScreen extends StatefulWidget {
-  static const String id = "edit_daily_goal";
+  static const String path = "/edit_daily_goal";
+  static const String name = "EditDailyGoalScreen";
   const EditDailyGoalScreen({super.key});
 
   @override

--- a/lib/features/water/screens/suggested_water_daily_goal_screen.dart
+++ b/lib/features/water/screens/suggested_water_daily_goal_screen.dart
@@ -1,18 +1,19 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:go_router/go_router.dart';
 import 'package:circle/core/core.dart';
+import 'package:hugeicons/hugeicons.dart';
 
 import '../../../components/bottom_nav_bar.dart';
 import '../../../components/components.dart';
 import '../../auth/auth.dart';
 import '../water.dart';
 
-
+@RoutePage(name: SuggestedWaterDailyGoalScreen.name)
 class SuggestedWaterDailyGoalScreen extends ConsumerStatefulWidget {
-  static const String id = "suggested_daily_goal";
+  static const String path = "/suggested_daily_goal";
+  static const String name = "SuggestedWaterDailyGoalScreen";
   const SuggestedWaterDailyGoalScreen({super.key});
 
   @override
@@ -35,6 +36,7 @@ class _SuggestedWaterDailyGoalScreenState
 
     return Scaffold(
       body: Column(
+        spacing: kPadding16,
         children: [
           CustomAppBar(
             showTitle: false,
@@ -43,7 +45,7 @@ class _SuggestedWaterDailyGoalScreenState
               AppButton(
                   isChipButton: true,
                   onPressed: () {
-                    context.goNamed(BottomNavBar.id);
+                    context.router.pushNamed(BottomNavBar .path);
                   },
                   label: "Skip",
                   buttonType: ButtonType.text),
@@ -51,9 +53,8 @@ class _SuggestedWaterDailyGoalScreenState
           ),
           Text(
             "Your daily goal",
-            style: theme.textTheme.displaySmall,
+            style: theme.textTheme.headlineMedium,
           ),
-          const Gap(24),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
@@ -61,11 +62,10 @@ class _SuggestedWaterDailyGoalScreenState
                 textAlign: TextAlign.center,
                 style: theme.textTheme.bodyMedium),
           ),
-          const Gap(64),
+          const Gap(48),
           Text("$defaultDailyGoal ml",
               style: theme.textTheme.displaySmall!
-                  .copyWith(fontWeight: FontWeight.w700)),
-          const Gap(24),
+                  .copyWith(color: theme.colorScheme.primary)),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
@@ -77,8 +77,38 @@ class _SuggestedWaterDailyGoalScreenState
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Column(
+              spacing: kPadding16,
               children: [
                 AppButton(
+                  isLoading: ref.watch(waterPrefsNotifierProviderImpl).isLoading,
+                  onPressed: () async {
+                    preferences = preferences?.copyWith(
+                      defaultDailyGoal: defaultDailyGoal,
+                    );
+                    await waterPrefsNotifier.putWaterPreferences(
+                        preferences: preferences!, user: user);
+                    if (context.mounted) {
+                      if(ref.watch(waterPrefsNotifierProviderImpl).hasError){
+                        showCustomSnackBar(
+                            context: context,
+                            message: "Failed to add data",
+                            mode: SnackBarMode.error);
+                      }else{
+                        showCustomSnackBar(
+                            context: context,
+                            message: "Preferences Updated",
+                            mode: SnackBarMode.success);
+                        context.router.pushNamed(BottomNavBar .path);
+                      }
+                    }
+                  },
+                  label: "Accept Goal & Continue",
+                ),
+                AppButton(
+                  label: "Change Goal",
+                  icon: HugeIcons.strokeRoundedPencilEdit02,
+                  buttonType: ButtonType.outline,
+
                   onPressed: () async {
                     await showModalBottomSheet(
                       context: context,
@@ -101,35 +131,7 @@ class _SuggestedWaterDailyGoalScreenState
                       ),
                     );
                   },
-                  label: "Change Goal",
-                  icon: FluentIcons.edit_24_regular,
-                  buttonType: ButtonType.outline,
-                ),
-                const Gap(16),
-                AppButton(
-                  isLoading: ref.watch(waterPrefsNotifierProviderImpl).isLoading,
-                  onPressed: () async {
-                    preferences = preferences?.copyWith(
-                      defaultDailyGoal: defaultDailyGoal,
-                    );
-                    await waterPrefsNotifier.putWaterPreferences(
-                        preferences: preferences!, user: user);
-                    if (context.mounted) {
-                      if(ref.watch(waterPrefsNotifierProviderImpl).hasError){
-                        showCustomSnackBar(
-                            context: context,
-                            message: "Failed to add data",
-                            mode: SnackBarMode.error);
-                      }else{
-                        showCustomSnackBar(
-                            context: context,
-                            message: "Preferences Updated",
-                            mode: SnackBarMode.success);
-                        context.goNamed(BottomNavBar.id);
-                      }
-                    }
-                  },
-                  label: "Accept Goal & Continue",
+
                 ),
               ],
             ),

--- a/lib/features/water/screens/water_empty_screen.dart
+++ b/lib/features/water/screens/water_empty_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
@@ -5,8 +6,10 @@ import 'package:circle/core/core.dart';
 
 import '../../../components/components.dart';
 
+@RoutePage(name: WaterEmptyScreen.name)
 class WaterEmptyScreen extends StatefulWidget {
-  static const String id = "water_goal_empty";
+  static const String path = "/water_goal_empty";
+  static const String name = "WaterEmptyScreen";
   const WaterEmptyScreen({super.key});
 
   @override

--- a/lib/features/water/screens/water_screen.dart
+++ b/lib/features/water/screens/water_screen.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/annotations.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -15,8 +16,10 @@ import 'charts/line_chart_widget.dart';
 import 'components/components.dart';
 import 'components/water_volume_selector.dart';
 
+@RoutePage(name: WaterScreen.name)
 class WaterScreen extends ConsumerStatefulWidget {
-  static const String id = "water";
+  static const String path = "/water";
+  static const String name = "WaterScreen";
   const WaterScreen({super.key});
 
   @override

--- a/lib/features/water/water.dart
+++ b/lib/features/water/water.dart
@@ -14,3 +14,4 @@ export 'providers/water_prefs_notifier.dart';
 export 'models/water_log.dart';
 export 'models/water_preferences.dart';
 export 'models/water_stats.dart';
+export 'screens/water_empty_screen.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
+
 import 'package:springster/springster.dart';
 
 import 'core/core.dart';
@@ -27,50 +27,39 @@ void main() async {
   // Initialize crashlytics
   CrashlyticsService.initialize();
 
-  runApp(const ProviderScope(child: MyApp()));
+  runApp(ProviderScope(child: MyApp()));
 }
 
-class MyApp extends ConsumerStatefulWidget {
-  const MyApp({super.key});
+class MyApp extends StatelessWidget {
+  MyApp({super.key});
 
-  @override
-  ConsumerState<MyApp> createState() => _MyAppState();
-}
-
-class _MyAppState extends ConsumerState<MyApp> {
-  GoRouter? router;
-  @override
-  void initState() {
-    router = ref.read(routerProvider);
-    super.initState();
-  }
-
+  final AppRouter _router = AppRouter();
   @override
   Widget build(BuildContext context) {
     return MaterialApp.router(
-        title: 'Circle',
-        debugShowCheckedModeBanner: true,
-        theme: AppThemeData.lightTheme,
-        darkTheme: AppThemeData.darkTheme,
-        themeMode: ThemeMode.system,
-        themeAnimationStyle: AnimationStyle(
-          curve: Spring.defaultIOS.toCurve,
-          duration: const Duration(milliseconds: 300),
-        ),
-        routerConfig: router,
-        // home: const AuthSuccessScreen()
-      );
-      // child: MaterialApp(
-      //   title: 'Circle',
-      //   debugShowCheckedModeBanner: true,
-      //   theme: AppThemeData.lightTheme,
-      //   darkTheme: AppThemeData.darkTheme,
-      //   themeMode: ThemeMode.system,
-      //   themeAnimationStyle: AnimationStyle(
-      //     curve: Spring.defaultIOS.toCurve,
-      //     duration: const Duration(milliseconds: 300),
-      //   ),
-      //   home: const GoogleSignInScreen()
-      // ),
+      title: 'Circle',
+      debugShowCheckedModeBanner: true,
+      theme: AppThemeData.lightTheme,
+      darkTheme: AppThemeData.darkTheme,
+      themeMode: ThemeMode.system,
+      themeAnimationStyle: AnimationStyle(
+        curve: Spring.defaultIOS.toCurve,
+        duration: const Duration(milliseconds: 300),
+      ),
+      routerConfig: _router.config(),
+      // home: const AuthSuccessScreen()
+    );
+    // child: MaterialApp(
+    //   title: 'Circle',
+    //   debugShowCheckedModeBanner: true,
+    //   theme: AppThemeData.lightTheme,
+    //   darkTheme: AppThemeData.darkTheme,
+    //   themeMode: ThemeMode.system,
+    //   themeAnimationStyle: AnimationStyle(
+    //     curve: Spring.defaultIOS.toCurve,
+    //     duration: const Duration(milliseconds: 300),
+    //   ),
+    //   home: const GoogleSignInScreen()
+    // ),
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -54,6 +54,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  auto_route:
+    dependency: "direct main"
+    description:
+      name: auto_route
+      sha256: "1d1bd908a1fec327719326d5d0791edd37f16caff6493c01003689fb03315ad7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.3.0+1"
+  auto_route_generator:
+    dependency: "direct dev"
+    description:
+      name: auto_route_generator
+      sha256: c9086eb07271e51b44071ad5cff34e889f3156710b964a308c2ab590769e79e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -589,14 +605,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  go_router:
-    dependency: "direct main"
-    description:
-      name: go_router
-      sha256: "7c2d40b59890a929824f30d442e810116caf5088482629c894b9e4478c67472d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "14.6.3"
   google_identity_services_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,6 @@ dependencies:
   percent_indicator: ^4.2.3
   fl_chart: ^0.70.1
   fpdart: ^1.1.0
-  go_router: ^14.2.8
   firebase_core: ^3.12.0
   firebase_auth: ^5.5.0
   cloud_firestore: ^5.6.4
@@ -62,7 +61,8 @@ dependencies:
   jiffy: ^6.3.2
   hugeicons: ^0.0.7
   springster: ^0.4.0
-#  sprung: ^3.0.1
+  auto_route: ^9.3.0+1
+
 
 dev_dependencies:
   flutter_test:
@@ -82,6 +82,7 @@ dev_dependencies:
   riverpod_generator: ^2.6.3
   objectbox_generator: ^4.1.0
   flutter_gen_runner: ^5.8.0
+  auto_route_generator: ^9.0.0
 
 
 # For information on the generic Dart part of this file, see the

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:circle/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget( MyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
Send Go Router to the depths of hell where it belongs😑 it was a fucken pain, to hell with it.

Migrated the project's navigation from go_router to auto_route.
Removed go_router as a dependency.
Added auto_route and auto_route_generator dependencies.
Implemented auto_route for all screens.
Replaced go_router methods with auto_route equivalents throughout the project.
Refactored route names and paths for clarity and consistency.
Updated app bar logic to use router.back() instead of go_router's pop().
Moved all route logic to auto_route generator

Other minor changes:
Updated app button colours when its button type is outline

Fixes: #33 
Fixes: #47 