### PR TITLE
feat: health connect integration (draft)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Circle is a Flutter app for managing Sickle Cell disease — medication tracking, water intake, vitals, and emergency contacts. Backend is Firebase (Auth, Firestore, Crashlytics, Analytics); local persistence is ObjectBox.
+
+## Commands
+
+```bash
+# Dependencies
+flutter pub get
+
+# Code generation (required after any changes to providers, routes, or ObjectBox entities)
+flutter pub run build_runner build --delete-conflicting-outputs
+# Watch mode during development
+flutter pub run build_runner watch --delete-conflicting-outputs
+
+# Lint and static analysis
+flutter analyze
+dart fix --apply
+
+# Tests
+flutter test
+flutter test test/path/to/specific_test.dart  # single test file
+
+# Run app
+flutter run
+
+# Build
+flutter build apk --debug
+flutter build apk --release
+flutter build appbundle --release
+```
+
+**Do not manually edit the version build number** (`pubspec.yaml` `+N`). CI/CD increments it automatically on release branches.
+
+## Architecture
+
+Feature-first layout under `lib/features/` with six features: `auth`, `meds`, `water`, `home`, `emergency`, `profile`. Each feature follows the same internal structure:
+
+```
+features/<name>/
+  models/       # Plain Dart/ObjectBox entity classes
+  services/     # Firebase + ObjectBox I/O (no business logic)
+  repositories/ # Abstract interfaces + implementations; wrap services, convert exceptions to Failure
+  providers/    # Riverpod notifiers; inject repositories, manage state
+  screens/      # UI only — reads provider state, dispatches actions
+```
+
+Shared code lives in `lib/core/` (routing, theme, error types, extensions, utils) and `lib/components/` (reusable widgets).
+
+### Data Flow
+
+```
+Screen → Notifier (Riverpod) → Repository → Service (Firebase/ObjectBox)
+```
+
+### Key Patterns
+
+**Functional error handling** — all async operations return `FutureEither<T>` (`Future<Either<Failure, T>>`), defined in `core/utils/typedefs.dart`. Use **fpdart** `Either`/`TaskEither` throughout; avoid bare try/catch in repositories.
+
+**Riverpod + code gen** — providers use `@Riverpod` annotation; generated base classes live in `*.g.dart` files. Notifiers extend `_$ClassName`. Run `build_runner` whenever annotations change.
+
+**AutoRoute** — routes are declared in `lib/core/routes/routes.dart` and generated into `routes.gr.dart`. Add new routes there and regenerate.
+
+**ObjectBox** — entities annotated with `@Entity()`. The store singleton is initialized in `lib/databse_service.dart` (note the typo in the filename). ObjectBox Admin runs on port 8091 in debug mode for inspecting the local DB.
+
+### State Management Details
+
+Notifiers receive repositories through their `build()` method (constructor injection via Riverpod). The pattern ensures testability — pass mock repositories in tests.
+
+### Theme
+
+Material 3. Colors, text styles, and spacing constants live in `lib/core/theme/`. Font is Plus Jakarta Sans. Don't hardcode colors or spacing — use `AppColors`, `AppTextStyles`, and `AppConstants`.
+
+## Code Generation Files
+
+These are generated — do not edit by hand:
+- `lib/objectbox.g.dart`, `lib/objectbox-model.json`
+- `lib/core/routes/routes.gr.dart`
+- `lib/gen/assets.gen.dart`, `lib/gen/fonts.gen.dart`
+- Any `*.g.dart` file alongside a provider/entity
+
+## CI/CD
+
+- PRs to `main`: runs `flutter analyze` + builds debug APK
+- PRs from `release/*` to `main`: auto-increments version, builds release artifacts, deploys to Play Store internal track
+- Create a `release/x.y.z` branch and PR to `main` to cut a release

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,10 +2,22 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+
+    <!-- Health Connect read permissions -->
+    <uses-permission android:name="android.permission.health.READ_STEPS"/>
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE"/>
+    <uses-permission android:name="android.permission.health.READ_BLOOD_OXYGEN"/>
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
+
     <application
         android:label="Circle"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
+        <!-- Health Connect permission rationale handler -->
+        <activity
+            android:name="androidx.health.connect.client.PermissionController"
+            android:exported="false"/>
+
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
         <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
@@ -43,7 +55,22 @@
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
             </intent-filter>
+            <!-- Health Connect permission rationale (Android 13 and below) -->
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
         </activity>
+        <!-- Health Connect permission rationale (Android 14+) -->
+        <activity-alias
+            android:name="ViewPermissionUsageActivity"
+            android:exported="true"
+            android:targetActivity=".MainActivity"
+            android:permission="android.permission.START_VIEW_PERMISSION_USAGE">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW_PERMISSION_USAGE" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
+            </intent-filter>
+        </activity-alias>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data
@@ -60,5 +87,7 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <!-- Allow the app to detect and launch the Health Connect app -->
+        <package android:name="com.google.android.apps.healthdata"/>
     </queries>
 </manifest>

--- a/android/app/src/main/kotlin/com/circleapp/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/circleapp/app/MainActivity.kt
@@ -1,5 +1,5 @@
 package co.circleapp.app
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity: FlutterActivity()
+class MainActivity: FlutterFragmentActivity()

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -2,6 +2,7 @@ import 'package:auto_route/auto_route.dart';
 import '../../components/bottom_nav_bar.dart';
 import '../../features/auth/auth.dart';
 import '../../features/emergency/emergency.dart';
+import '../../features/health_connect/health_connect.dart';
 import '../../features/home/home.dart';
 import '../../features/meds/meds.dart';
 import '../../features/profile/profile.dart';
@@ -29,6 +30,9 @@ class AppRouter extends RootStackRouter {
       path: SuggestedWaterDailyGoalScreen.path,
     ),
     AutoRoute(page: route.WaterEmptyScreen.page, path: WaterEmptyScreen.path),
+
+    // ////-------Health Connect-------//// //
+    AutoRoute(page: route.HealthScreen.page, path: HealthScreen.path),
 
     // ////-------Emergency-------//// //
     AutoRoute(page: route.EmergencyScreen.page, path: EmergencyScreen.path),

--- a/lib/core/routes/routes.gr.dart
+++ b/lib/core/routes/routes.gr.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 // **************************************************************************
@@ -8,56 +9,55 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_route/auto_route.dart' as _i25;
+import 'package:auto_route/auto_route.dart' as _i26;
 import 'package:circle/components/bottom_nav_bar.dart' as _i4;
 import 'package:circle/features/auth/screens/auth/auth_success.dart' as _i3;
 import 'package:circle/features/auth/screens/auth/google_sign_in_screen.dart'
     as _i8;
-import 'package:circle/features/auth/screens/auth/loading_screen.dart' as _i10;
-import 'package:circle/features/auth/screens/auth/register_screen.dart' as _i19;
-import 'package:circle/features/auth/screens/auth/sign_in_screen.dart' as _i21;
+import 'package:circle/features/auth/screens/auth/loading_screen.dart' as _i11;
+import 'package:circle/features/auth/screens/auth/register_screen.dart' as _i20;
+import 'package:circle/features/auth/screens/auth/sign_in_screen.dart' as _i22;
 import 'package:circle/features/auth/screens/onboarding/onboarding_base_screen.dart'
-    as _i14;
+    as _i15;
 import 'package:circle/features/emergency/screens/add_emergency_contact_screen.dart'
     as _i1;
 import 'package:circle/features/emergency/screens/crisis_logs_screen.dart'
     as _i5;
 import 'package:circle/features/emergency/screens/emergency_screen.dart' as _i7;
-import 'package:circle/features/home/screens/home_screen.dart' as _i9;
-import 'package:circle/features/meds/models/medication.dart' as _i27;
+import 'package:circle/features/health_connect/screens/health_screen.dart'
+    as _i9;
+import 'package:circle/features/home/screens/home_screen.dart' as _i10;
+import 'package:circle/features/meds/models/medication.dart' as _i28;
 import 'package:circle/features/meds/screens/add_edit_meds_screen.dart' as _i2;
-import 'package:circle/features/meds/screens/meds_details_screen.dart' as _i11;
-import 'package:circle/features/meds/screens/meds_schedule_screen.dart' as _i12;
-import 'package:circle/features/meds/screens/meds_screen.dart' as _i13;
+import 'package:circle/features/meds/screens/meds_details_screen.dart' as _i12;
+import 'package:circle/features/meds/screens/meds_schedule_screen.dart' as _i13;
+import 'package:circle/features/meds/screens/meds_screen.dart' as _i14;
 import 'package:circle/features/profile/screens/profile_basic_info_screen.dart'
-    as _i15;
-import 'package:circle/features/profile/screens/profile_medical_info_screen.dart'
     as _i16;
-import 'package:circle/features/profile/screens/profile_screen.dart' as _i17;
+import 'package:circle/features/profile/screens/profile_medical_info_screen.dart'
+    as _i17;
+import 'package:circle/features/profile/screens/profile_screen.dart' as _i18;
 import 'package:circle/features/profile/screens/profile_vitals_info_screen.dart'
-    as _i18;
-import 'package:circle/features/profile/screens/settings_screen.dart' as _i20;
+    as _i19;
+import 'package:circle/features/profile/screens/settings_screen.dart' as _i21;
 import 'package:circle/features/water/screens/edit_daily_goal_screen.dart'
     as _i6;
 import 'package:circle/features/water/screens/suggested_water_daily_goal_screen.dart'
-    as _i22;
-import 'package:circle/features/water/screens/water_empty_screen.dart' as _i23;
-import 'package:circle/features/water/screens/water_screen.dart' as _i24;
-import 'package:flutter/cupertino.dart' as _i26;
-import 'package:flutter/material.dart' as _i28;
+    as _i23;
+import 'package:circle/features/water/screens/water_empty_screen.dart' as _i24;
+import 'package:circle/features/water/screens/water_screen.dart' as _i25;
+import 'package:flutter/cupertino.dart' as _i27;
+import 'package:flutter/material.dart' as _i29;
 
 /// generated route for
 /// [_i1.AddEmergencyContactScreen]
-class AddEmergencyContactScreen extends _i25.PageRouteInfo<void> {
-  const AddEmergencyContactScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          AddEmergencyContactScreen.name,
-          initialChildren: children,
-        );
+class AddEmergencyContactScreen extends _i26.PageRouteInfo<void> {
+  const AddEmergencyContactScreen({List<_i26.PageRouteInfo>? children})
+    : super(AddEmergencyContactScreen.name, initialChildren: children);
 
   static const String name = 'AddEmergencyContactScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i1.AddEmergencyContactScreen();
@@ -67,29 +67,30 @@ class AddEmergencyContactScreen extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i2.AddMedsScreen]
-class AddMedsScreen extends _i25.PageRouteInfo<AddMedsScreenArgs> {
+class AddMedsScreen extends _i26.PageRouteInfo<AddMedsScreenArgs> {
   AddMedsScreen({
-    _i26.Key? key,
+    _i27.Key? key,
     bool isEditing = false,
-    _i27.Medication? medicationToEdit,
-    List<_i25.PageRouteInfo>? children,
+    _i28.Medication? medicationToEdit,
+    List<_i26.PageRouteInfo>? children,
   }) : super(
-          AddMedsScreen.name,
-          args: AddMedsScreenArgs(
-            key: key,
-            isEditing: isEditing,
-            medicationToEdit: medicationToEdit,
-          ),
-          initialChildren: children,
-        );
+         AddMedsScreen.name,
+         args: AddMedsScreenArgs(
+           key: key,
+           isEditing: isEditing,
+           medicationToEdit: medicationToEdit,
+         ),
+         initialChildren: children,
+       );
 
   static const String name = 'AddMedsScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<AddMedsScreenArgs>(
-          orElse: () => const AddMedsScreenArgs());
+        orElse: () => const AddMedsScreenArgs(),
+      );
       return _i2.AddMedsScreen(
         key: args.key,
         isEditing: args.isEditing,
@@ -106,11 +107,11 @@ class AddMedsScreenArgs {
     this.medicationToEdit,
   });
 
-  final _i26.Key? key;
+  final _i27.Key? key;
 
   final bool isEditing;
 
-  final _i27.Medication? medicationToEdit;
+  final _i28.Medication? medicationToEdit;
 
   @override
   String toString() {
@@ -120,16 +121,13 @@ class AddMedsScreenArgs {
 
 /// generated route for
 /// [_i3.AuthSuccessScreen]
-class AuthSuccessScreen extends _i25.PageRouteInfo<void> {
-  const AuthSuccessScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          AuthSuccessScreen.name,
-          initialChildren: children,
-        );
+class AuthSuccessScreen extends _i26.PageRouteInfo<void> {
+  const AuthSuccessScreen({List<_i26.PageRouteInfo>? children})
+    : super(AuthSuccessScreen.name, initialChildren: children);
 
   static const String name = 'AuthSuccessScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i3.AuthSuccessScreen();
@@ -139,16 +137,13 @@ class AuthSuccessScreen extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i4.BottomNavBar]
-class BottomNavBar extends _i25.PageRouteInfo<void> {
-  const BottomNavBar({List<_i25.PageRouteInfo>? children})
-      : super(
-          BottomNavBar.name,
-          initialChildren: children,
-        );
+class BottomNavBar extends _i26.PageRouteInfo<void> {
+  const BottomNavBar({List<_i26.PageRouteInfo>? children})
+    : super(BottomNavBar.name, initialChildren: children);
 
   static const String name = 'BottomNavBar';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i4.BottomNavBar();
@@ -158,16 +153,13 @@ class BottomNavBar extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i5.CrisisLogsScreen]
-class CrisisLogsScreen extends _i25.PageRouteInfo<void> {
-  const CrisisLogsScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          CrisisLogsScreen.name,
-          initialChildren: children,
-        );
+class CrisisLogsScreen extends _i26.PageRouteInfo<void> {
+  const CrisisLogsScreen({List<_i26.PageRouteInfo>? children})
+    : super(CrisisLogsScreen.name, initialChildren: children);
 
   static const String name = 'CrisisLogsScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i5.CrisisLogsScreen();
@@ -177,16 +169,13 @@ class CrisisLogsScreen extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i6.EditDailyGoalScreen]
-class EditDailyGoalScreen extends _i25.PageRouteInfo<void> {
-  const EditDailyGoalScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          EditDailyGoalScreen.name,
-          initialChildren: children,
-        );
+class EditDailyGoalScreen extends _i26.PageRouteInfo<void> {
+  const EditDailyGoalScreen({List<_i26.PageRouteInfo>? children})
+    : super(EditDailyGoalScreen.name, initialChildren: children);
 
   static const String name = 'EditDailyGoalScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i6.EditDailyGoalScreen();
@@ -196,16 +185,13 @@ class EditDailyGoalScreen extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i7.EmergencyScreen]
-class EmergencyScreen extends _i25.PageRouteInfo<void> {
-  const EmergencyScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          EmergencyScreen.name,
-          initialChildren: children,
-        );
+class EmergencyScreen extends _i26.PageRouteInfo<void> {
+  const EmergencyScreen({List<_i26.PageRouteInfo>? children})
+    : super(EmergencyScreen.name, initialChildren: children);
 
   static const String name = 'EmergencyScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i7.EmergencyScreen();
@@ -215,16 +201,13 @@ class EmergencyScreen extends _i25.PageRouteInfo<void> {
 
 /// generated route for
 /// [_i8.GoogleSignInScreen]
-class GoogleSignInScreen extends _i25.PageRouteInfo<void> {
-  const GoogleSignInScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          GoogleSignInScreen.name,
-          initialChildren: children,
-        );
+class GoogleSignInScreen extends _i26.PageRouteInfo<void> {
+  const GoogleSignInScreen({List<_i26.PageRouteInfo>? children})
+    : super(GoogleSignInScreen.name, initialChildren: children);
 
   static const String name = 'GoogleSignInScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       return const _i8.GoogleSignInScreen();
@@ -233,144 +216,140 @@ class GoogleSignInScreen extends _i25.PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [_i9.HomeScreen]
-class HomeScreen extends _i25.PageRouteInfo<void> {
-  const HomeScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          HomeScreen.name,
-          initialChildren: children,
-        );
+/// [_i9.HealthScreen]
+class HealthScreen extends _i26.PageRouteInfo<void> {
+  const HealthScreen({List<_i26.PageRouteInfo>? children})
+    : super(HealthScreen.name, initialChildren: children);
+
+  static const String name = 'HealthScreen';
+
+  static _i26.PageInfo page = _i26.PageInfo(
+    name,
+    builder: (data) {
+      return const _i9.HealthScreen();
+    },
+  );
+}
+
+/// generated route for
+/// [_i10.HomeScreen]
+class HomeScreen extends _i26.PageRouteInfo<void> {
+  const HomeScreen({List<_i26.PageRouteInfo>? children})
+    : super(HomeScreen.name, initialChildren: children);
 
   static const String name = 'HomeScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i9.HomeScreen();
+      return const _i10.HomeScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i10.LoadingScreen]
-class LoadingScreen extends _i25.PageRouteInfo<void> {
-  const LoadingScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          LoadingScreen.name,
-          initialChildren: children,
-        );
+/// [_i11.LoadingScreen]
+class LoadingScreen extends _i26.PageRouteInfo<void> {
+  const LoadingScreen({List<_i26.PageRouteInfo>? children})
+    : super(LoadingScreen.name, initialChildren: children);
 
   static const String name = 'LoadingScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i10.LoadingScreen();
+      return const _i11.LoadingScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i11.MedsDetailsScreen]
-class MedsDetailsScreen extends _i25.PageRouteInfo<void> {
-  const MedsDetailsScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          MedsDetailsScreen.name,
-          initialChildren: children,
-        );
+/// [_i12.MedsDetailsScreen]
+class MedsDetailsScreen extends _i26.PageRouteInfo<void> {
+  const MedsDetailsScreen({List<_i26.PageRouteInfo>? children})
+    : super(MedsDetailsScreen.name, initialChildren: children);
 
   static const String name = 'MedsDetailsScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i11.MedsDetailsScreen();
+      return const _i12.MedsDetailsScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i12.MedsScheduleScreen]
-class MedsScheduleScreen extends _i25.PageRouteInfo<void> {
-  const MedsScheduleScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          MedsScheduleScreen.name,
-          initialChildren: children,
-        );
+/// [_i13.MedsScheduleScreen]
+class MedsScheduleScreen extends _i26.PageRouteInfo<void> {
+  const MedsScheduleScreen({List<_i26.PageRouteInfo>? children})
+    : super(MedsScheduleScreen.name, initialChildren: children);
 
   static const String name = 'MedsScheduleScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i12.MedsScheduleScreen();
+      return const _i13.MedsScheduleScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i13.MedsScreen]
-class MedsScreen extends _i25.PageRouteInfo<void> {
-  const MedsScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          MedsScreen.name,
-          initialChildren: children,
-        );
+/// [_i14.MedsScreen]
+class MedsScreen extends _i26.PageRouteInfo<void> {
+  const MedsScreen({List<_i26.PageRouteInfo>? children})
+    : super(MedsScreen.name, initialChildren: children);
 
   static const String name = 'MedsScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i13.MedsScreen();
+      return const _i14.MedsScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i14.OnboardingBaseScreen]
-class OnboardingBaseScreen extends _i25.PageRouteInfo<void> {
-  const OnboardingBaseScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          OnboardingBaseScreen.name,
-          initialChildren: children,
-        );
+/// [_i15.OnboardingBaseScreen]
+class OnboardingBaseScreen extends _i26.PageRouteInfo<void> {
+  const OnboardingBaseScreen({List<_i26.PageRouteInfo>? children})
+    : super(OnboardingBaseScreen.name, initialChildren: children);
 
   static const String name = 'OnboardingBaseScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i14.OnboardingBaseScreen();
+      return const _i15.OnboardingBaseScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i15.ProfileBasicInfoScreen]
+/// [_i16.ProfileBasicInfoScreen]
 class ProfileBasicInfoScreen
-    extends _i25.PageRouteInfo<ProfileBasicInfoScreenArgs> {
+    extends _i26.PageRouteInfo<ProfileBasicInfoScreenArgs> {
   ProfileBasicInfoScreen({
-    _i28.Key? key,
+    _i29.Key? key,
     bool? isEditing = false,
-    List<_i25.PageRouteInfo>? children,
+    List<_i26.PageRouteInfo>? children,
   }) : super(
-          ProfileBasicInfoScreen.name,
-          args: ProfileBasicInfoScreenArgs(
-            key: key,
-            isEditing: isEditing,
-          ),
-          initialChildren: children,
-        );
+         ProfileBasicInfoScreen.name,
+         args: ProfileBasicInfoScreenArgs(key: key, isEditing: isEditing),
+         initialChildren: children,
+       );
 
   static const String name = 'ProfileBasicInfoScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<ProfileBasicInfoScreenArgs>(
-          orElse: () => const ProfileBasicInfoScreenArgs());
-      return _i15.ProfileBasicInfoScreen(
+        orElse: () => const ProfileBasicInfoScreenArgs(),
+      );
+      return _i16.ProfileBasicInfoScreen(
         key: args.key,
         isEditing: args.isEditing,
       );
@@ -379,12 +358,9 @@ class ProfileBasicInfoScreen
 }
 
 class ProfileBasicInfoScreenArgs {
-  const ProfileBasicInfoScreenArgs({
-    this.key,
-    this.isEditing = false,
-  });
+  const ProfileBasicInfoScreenArgs({this.key, this.isEditing = false});
 
-  final _i28.Key? key;
+  final _i29.Key? key;
 
   final bool? isEditing;
 
@@ -395,30 +371,28 @@ class ProfileBasicInfoScreenArgs {
 }
 
 /// generated route for
-/// [_i16.ProfileMedicalInfoScreen]
+/// [_i17.ProfileMedicalInfoScreen]
 class ProfileMedicalInfoScreen
-    extends _i25.PageRouteInfo<ProfileMedicalInfoScreenArgs> {
+    extends _i26.PageRouteInfo<ProfileMedicalInfoScreenArgs> {
   ProfileMedicalInfoScreen({
-    _i28.Key? key,
+    _i29.Key? key,
     bool? isEditing = false,
-    List<_i25.PageRouteInfo>? children,
+    List<_i26.PageRouteInfo>? children,
   }) : super(
-          ProfileMedicalInfoScreen.name,
-          args: ProfileMedicalInfoScreenArgs(
-            key: key,
-            isEditing: isEditing,
-          ),
-          initialChildren: children,
-        );
+         ProfileMedicalInfoScreen.name,
+         args: ProfileMedicalInfoScreenArgs(key: key, isEditing: isEditing),
+         initialChildren: children,
+       );
 
   static const String name = 'ProfileMedicalInfoScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<ProfileMedicalInfoScreenArgs>(
-          orElse: () => const ProfileMedicalInfoScreenArgs());
-      return _i16.ProfileMedicalInfoScreen(
+        orElse: () => const ProfileMedicalInfoScreenArgs(),
+      );
+      return _i17.ProfileMedicalInfoScreen(
         key: args.key,
         isEditing: args.isEditing,
       );
@@ -427,12 +401,9 @@ class ProfileMedicalInfoScreen
 }
 
 class ProfileMedicalInfoScreenArgs {
-  const ProfileMedicalInfoScreenArgs({
-    this.key,
-    this.isEditing = false,
-  });
+  const ProfileMedicalInfoScreenArgs({this.key, this.isEditing = false});
 
-  final _i28.Key? key;
+  final _i29.Key? key;
 
   final bool? isEditing;
 
@@ -443,49 +414,44 @@ class ProfileMedicalInfoScreenArgs {
 }
 
 /// generated route for
-/// [_i17.ProfileScreen]
-class ProfileScreen extends _i25.PageRouteInfo<void> {
-  const ProfileScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          ProfileScreen.name,
-          initialChildren: children,
-        );
+/// [_i18.ProfileScreen]
+class ProfileScreen extends _i26.PageRouteInfo<void> {
+  const ProfileScreen({List<_i26.PageRouteInfo>? children})
+    : super(ProfileScreen.name, initialChildren: children);
 
   static const String name = 'ProfileScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i17.ProfileScreen();
+      return const _i18.ProfileScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i18.ProfileVitalsInfoScreen]
+/// [_i19.ProfileVitalsInfoScreen]
 class ProfileVitalsInfoScreen
-    extends _i25.PageRouteInfo<ProfileVitalsInfoScreenArgs> {
+    extends _i26.PageRouteInfo<ProfileVitalsInfoScreenArgs> {
   ProfileVitalsInfoScreen({
-    _i28.Key? key,
+    _i29.Key? key,
     bool? isEditing = false,
-    List<_i25.PageRouteInfo>? children,
+    List<_i26.PageRouteInfo>? children,
   }) : super(
-          ProfileVitalsInfoScreen.name,
-          args: ProfileVitalsInfoScreenArgs(
-            key: key,
-            isEditing: isEditing,
-          ),
-          initialChildren: children,
-        );
+         ProfileVitalsInfoScreen.name,
+         args: ProfileVitalsInfoScreenArgs(key: key, isEditing: isEditing),
+         initialChildren: children,
+       );
 
   static const String name = 'ProfileVitalsInfoScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
       final args = data.argsAs<ProfileVitalsInfoScreenArgs>(
-          orElse: () => const ProfileVitalsInfoScreenArgs());
-      return _i18.ProfileVitalsInfoScreen(
+        orElse: () => const ProfileVitalsInfoScreenArgs(),
+      );
+      return _i19.ProfileVitalsInfoScreen(
         key: args.key,
         isEditing: args.isEditing,
       );
@@ -494,12 +460,9 @@ class ProfileVitalsInfoScreen
 }
 
 class ProfileVitalsInfoScreenArgs {
-  const ProfileVitalsInfoScreenArgs({
-    this.key,
-    this.isEditing = false,
-  });
+  const ProfileVitalsInfoScreenArgs({this.key, this.isEditing = false});
 
-  final _i28.Key? key;
+  final _i29.Key? key;
 
   final bool? isEditing;
 
@@ -510,115 +473,97 @@ class ProfileVitalsInfoScreenArgs {
 }
 
 /// generated route for
-/// [_i19.RegisterScreen]
-class RegisterScreen extends _i25.PageRouteInfo<void> {
-  const RegisterScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          RegisterScreen.name,
-          initialChildren: children,
-        );
+/// [_i20.RegisterScreen]
+class RegisterScreen extends _i26.PageRouteInfo<void> {
+  const RegisterScreen({List<_i26.PageRouteInfo>? children})
+    : super(RegisterScreen.name, initialChildren: children);
 
   static const String name = 'RegisterScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i19.RegisterScreen();
+      return const _i20.RegisterScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i20.SettingsScreen]
-class SettingsScreen extends _i25.PageRouteInfo<void> {
-  const SettingsScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          SettingsScreen.name,
-          initialChildren: children,
-        );
+/// [_i21.SettingsScreen]
+class SettingsScreen extends _i26.PageRouteInfo<void> {
+  const SettingsScreen({List<_i26.PageRouteInfo>? children})
+    : super(SettingsScreen.name, initialChildren: children);
 
   static const String name = 'SettingsScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i20.SettingsScreen();
+      return const _i21.SettingsScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i21.SignInScreen]
-class SignInScreen extends _i25.PageRouteInfo<void> {
-  const SignInScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          SignInScreen.name,
-          initialChildren: children,
-        );
+/// [_i22.SignInScreen]
+class SignInScreen extends _i26.PageRouteInfo<void> {
+  const SignInScreen({List<_i26.PageRouteInfo>? children})
+    : super(SignInScreen.name, initialChildren: children);
 
   static const String name = 'SignInScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i21.SignInScreen();
+      return const _i22.SignInScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i22.SuggestedWaterDailyGoalScreen]
-class SuggestedWaterDailyGoalScreen extends _i25.PageRouteInfo<void> {
-  const SuggestedWaterDailyGoalScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          SuggestedWaterDailyGoalScreen.name,
-          initialChildren: children,
-        );
+/// [_i23.SuggestedWaterDailyGoalScreen]
+class SuggestedWaterDailyGoalScreen extends _i26.PageRouteInfo<void> {
+  const SuggestedWaterDailyGoalScreen({List<_i26.PageRouteInfo>? children})
+    : super(SuggestedWaterDailyGoalScreen.name, initialChildren: children);
 
   static const String name = 'SuggestedWaterDailyGoalScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i22.SuggestedWaterDailyGoalScreen();
+      return const _i23.SuggestedWaterDailyGoalScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i23.WaterEmptyScreen]
-class WaterEmptyScreen extends _i25.PageRouteInfo<void> {
-  const WaterEmptyScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          WaterEmptyScreen.name,
-          initialChildren: children,
-        );
+/// [_i24.WaterEmptyScreen]
+class WaterEmptyScreen extends _i26.PageRouteInfo<void> {
+  const WaterEmptyScreen({List<_i26.PageRouteInfo>? children})
+    : super(WaterEmptyScreen.name, initialChildren: children);
 
   static const String name = 'WaterEmptyScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i23.WaterEmptyScreen();
+      return const _i24.WaterEmptyScreen();
     },
   );
 }
 
 /// generated route for
-/// [_i24.WaterScreen]
-class WaterScreen extends _i25.PageRouteInfo<void> {
-  const WaterScreen({List<_i25.PageRouteInfo>? children})
-      : super(
-          WaterScreen.name,
-          initialChildren: children,
-        );
+/// [_i25.WaterScreen]
+class WaterScreen extends _i26.PageRouteInfo<void> {
+  const WaterScreen({List<_i26.PageRouteInfo>? children})
+    : super(WaterScreen.name, initialChildren: children);
 
   static const String name = 'WaterScreen';
 
-  static _i25.PageInfo page = _i25.PageInfo(
+  static _i26.PageInfo page = _i26.PageInfo(
     name,
     builder: (data) {
-      return const _i24.WaterScreen();
+      return const _i25.WaterScreen();
     },
   );
 }

--- a/lib/features/auth/providers/auth/auth_notifier.g.dart
+++ b/lib/features/auth/providers/auth/auth_notifier.g.dart
@@ -32,9 +32,7 @@ class _SystemHash {
 abstract class _$AuthNotifier extends BuildlessAsyncNotifier<AppUser> {
   late final AuthRepository authRepository;
 
-  FutureOr<AppUser> build({
-    required AuthRepository authRepository,
-  });
+  FutureOr<AppUser> build({required AuthRepository authRepository});
 }
 
 /// See also [AuthNotifier].
@@ -47,21 +45,15 @@ class AuthNotifierFamily extends Family<AsyncValue<AppUser>> {
   const AuthNotifierFamily();
 
   /// See also [AuthNotifier].
-  AuthNotifierProvider call({
-    required AuthRepository authRepository,
-  }) {
-    return AuthNotifierProvider(
-      authRepository: authRepository,
-    );
+  AuthNotifierProvider call({required AuthRepository authRepository}) {
+    return AuthNotifierProvider(authRepository: authRepository);
   }
 
   @override
   AuthNotifierProvider getProviderOverride(
     covariant AuthNotifierProvider provider,
   ) {
-    return call(
-      authRepository: provider.authRepository,
-    );
+    return call(authRepository: provider.authRepository);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -83,21 +75,20 @@ class AuthNotifierFamily extends Family<AsyncValue<AppUser>> {
 class AuthNotifierProvider
     extends AsyncNotifierProviderImpl<AuthNotifier, AppUser> {
   /// See also [AuthNotifier].
-  AuthNotifierProvider({
-    required AuthRepository authRepository,
-  }) : this._internal(
-          () => AuthNotifier()..authRepository = authRepository,
-          from: authNotifierProvider,
-          name: r'authNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$authNotifierHash,
-          dependencies: AuthNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              AuthNotifierFamily._allTransitiveDependencies,
-          authRepository: authRepository,
-        );
+  AuthNotifierProvider({required AuthRepository authRepository})
+    : this._internal(
+        () => AuthNotifier()..authRepository = authRepository,
+        from: authNotifierProvider,
+        name: r'authNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$authNotifierHash,
+        dependencies: AuthNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            AuthNotifierFamily._allTransitiveDependencies,
+        authRepository: authRepository,
+      );
 
   AuthNotifierProvider._internal(
     super._createNotifier, {
@@ -112,12 +103,8 @@ class AuthNotifierProvider
   final AuthRepository authRepository;
 
   @override
-  FutureOr<AppUser> runNotifierBuild(
-    covariant AuthNotifier notifier,
-  ) {
-    return notifier.build(
-      authRepository: authRepository,
-    );
+  FutureOr<AppUser> runNotifierBuild(covariant AuthNotifier notifier) {
+    return notifier.build(authRepository: authRepository);
   }
 
   @override
@@ -172,5 +159,6 @@ class _AuthNotifierProviderElement
   AuthRepository get authRepository =>
       (origin as AuthNotifierProvider).authRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/auth/providers/user/user_notifier.g.dart
+++ b/lib/features/auth/providers/user/user_notifier.g.dart
@@ -32,9 +32,7 @@ class _SystemHash {
 abstract class _$UserNotifier extends BuildlessAsyncNotifier<AppUser> {
   late final UserRepository userRepository;
 
-  FutureOr<AppUser> build({
-    required UserRepository userRepository,
-  });
+  FutureOr<AppUser> build({required UserRepository userRepository});
 }
 
 /// See also [UserNotifier].
@@ -47,21 +45,15 @@ class UserNotifierFamily extends Family<AsyncValue<AppUser>> {
   const UserNotifierFamily();
 
   /// See also [UserNotifier].
-  UserNotifierProvider call({
-    required UserRepository userRepository,
-  }) {
-    return UserNotifierProvider(
-      userRepository: userRepository,
-    );
+  UserNotifierProvider call({required UserRepository userRepository}) {
+    return UserNotifierProvider(userRepository: userRepository);
   }
 
   @override
   UserNotifierProvider getProviderOverride(
     covariant UserNotifierProvider provider,
   ) {
-    return call(
-      userRepository: provider.userRepository,
-    );
+    return call(userRepository: provider.userRepository);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -83,21 +75,20 @@ class UserNotifierFamily extends Family<AsyncValue<AppUser>> {
 class UserNotifierProvider
     extends AsyncNotifierProviderImpl<UserNotifier, AppUser> {
   /// See also [UserNotifier].
-  UserNotifierProvider({
-    required UserRepository userRepository,
-  }) : this._internal(
-          () => UserNotifier()..userRepository = userRepository,
-          from: userNotifierProvider,
-          name: r'userNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$userNotifierHash,
-          dependencies: UserNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              UserNotifierFamily._allTransitiveDependencies,
-          userRepository: userRepository,
-        );
+  UserNotifierProvider({required UserRepository userRepository})
+    : this._internal(
+        () => UserNotifier()..userRepository = userRepository,
+        from: userNotifierProvider,
+        name: r'userNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$userNotifierHash,
+        dependencies: UserNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            UserNotifierFamily._allTransitiveDependencies,
+        userRepository: userRepository,
+      );
 
   UserNotifierProvider._internal(
     super._createNotifier, {
@@ -112,12 +103,8 @@ class UserNotifierProvider
   final UserRepository userRepository;
 
   @override
-  FutureOr<AppUser> runNotifierBuild(
-    covariant UserNotifier notifier,
-  ) {
-    return notifier.build(
-      userRepository: userRepository,
-    );
+  FutureOr<AppUser> runNotifierBuild(covariant UserNotifier notifier) {
+    return notifier.build(userRepository: userRepository);
   }
 
   @override
@@ -172,5 +159,6 @@ class _UserNotifierProviderElement
   UserRepository get userRepository =>
       (origin as UserNotifierProvider).userRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/health_connect/health_connect.dart
+++ b/lib/features/health_connect/health_connect.dart
@@ -1,0 +1,6 @@
+export 'models/health_record.dart';
+export 'models/health_summary.dart';
+export 'services/health_connect_service.dart';
+export 'repositories/health_repository.dart';
+export 'providers/health_connect_notifier.dart';
+export 'screens/health_screen.dart';

--- a/lib/features/health_connect/models/health_record.dart
+++ b/lib/features/health_connect/models/health_record.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+
+/// A single heart rate measurement read from Health Connect.
+///
+/// These are in-memory only — Health Connect is treated as the source of
+/// truth, so there is no ObjectBox persistence for health records.
+class HeartRateRecord extends Equatable {
+  /// The moment the reading was taken.
+  final DateTime timestamp;
+
+  /// Beats per minute.
+  final int bpm;
+
+  const HeartRateRecord({required this.timestamp, required this.bpm});
+
+  @override
+  List<Object?> get props => [timestamp, bpm];
+}
+
+/// A single blood oxygen / SpO2 measurement read from Health Connect.
+class BloodOxygenRecord extends Equatable {
+  /// The moment the reading was taken.
+  final DateTime timestamp;
+
+  /// SpO2 saturation as a percentage (0–100).
+  final double percentage;
+
+  const BloodOxygenRecord({required this.timestamp, required this.percentage});
+
+  @override
+  List<Object?> get props => [timestamp, percentage];
+}

--- a/lib/features/health_connect/models/health_summary.dart
+++ b/lib/features/health_connect/models/health_summary.dart
@@ -1,0 +1,64 @@
+import 'package:equatable/equatable.dart';
+
+import 'health_record.dart';
+
+/// The state of the user's Health Connect permission grant.
+///
+/// Lives here because it is a domain concept shared by both the repository
+/// (which maps raw platform booleans onto it) and the providers/UI (which
+/// branch on it).
+enum HealthPermissionStatus {
+  /// Permission has not been checked yet.
+  unknown,
+
+  /// Health Connect is not available on this device (e.g. not installed,
+  /// or the platform is unsupported).
+  notAvailable,
+
+  /// Health Connect is available but the user has not granted access.
+  denied,
+
+  /// The user has granted read access to the requested data types.
+  granted,
+}
+
+/// An aggregated, read-only snapshot of the user's health metrics.
+///
+/// Constructed by the repository from the raw service results and held in the
+/// summary notifier's state.
+class HealthSummary extends Equatable {
+  /// Total steps recorded for today (null if unavailable).
+  final int? stepsToday;
+
+  /// The most recent heart rate reading (null if unavailable).
+  final HeartRateRecord? latestHeartRate;
+
+  /// The most recent blood oxygen reading (null if unavailable).
+  final BloodOxygenRecord? latestBloodOxygen;
+
+  /// Recent heart rate readings, newest first, for the detail screen.
+  final List<HeartRateRecord> recentHeartRates;
+
+  /// Recent blood oxygen readings, newest first, for the detail screen.
+  final List<BloodOxygenRecord> recentBloodOxygenReadings;
+
+  const HealthSummary({
+    this.stepsToday,
+    this.latestHeartRate,
+    this.latestBloodOxygen,
+    this.recentHeartRates = const [],
+    this.recentBloodOxygenReadings = const [],
+  });
+
+  /// An empty summary, used as the initial notifier state.
+  static const HealthSummary empty = HealthSummary();
+
+  @override
+  List<Object?> get props => [
+        stepsToday,
+        latestHeartRate,
+        latestBloodOxygen,
+        recentHeartRates,
+        recentBloodOxygenReadings,
+      ];
+}

--- a/lib/features/health_connect/providers/health_connect_notifier.dart
+++ b/lib/features/health_connect/providers/health_connect_notifier.dart
@@ -1,0 +1,131 @@
+import 'dart:developer';
+
+import 'package:fpdart/fpdart.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../core/core.dart';
+import '../health_connect.dart';
+
+part 'health_connect_notifier.g.dart';
+
+// ─── Singleton wiring (same pattern as the water/meds features) ──────────────
+
+final HealthConnectService healthConnectService = HealthConnectService();
+
+final HealthRepository healthRepository = HealthRepositoryImpl(
+  service: healthConnectService,
+);
+
+final HealthPermissionNotifierProvider healthPermissionNotifierProviderImpl =
+    healthPermissionNotifierProvider(healthRepository: healthRepository);
+
+final HealthSummaryNotifierProvider healthSummaryNotifierProviderImpl =
+    healthSummaryNotifierProvider(healthRepository: healthRepository);
+
+// ─── Permission notifier ─────────────────────────────────────────────────────
+
+/// Holds the Health Connect permission state, kept separate from the data
+/// notifier because permission and data have different lifecycles.
+@Riverpod(keepAlive: true)
+class HealthPermissionNotifier extends _$HealthPermissionNotifier {
+  late final HealthRepository _healthRepository;
+
+  @override
+  FutureOr<HealthPermissionStatus> build({
+    required HealthRepository healthRepository,
+  }) async {
+    _healthRepository = healthRepository;
+    return HealthPermissionStatus.unknown;
+  }
+
+  Future<void> checkPermissions() async {
+    log('Checking Health Connect permissions',
+        name: 'HealthPermissionNotifier');
+    state = const AsyncValue.loading();
+    final Either<Failure, HealthPermissionStatus> response =
+        await _healthRepository.checkPermissions();
+    response.fold(
+      (failure) {
+        log(
+          'Failed: $failure, Message: ${failure.message}, Code: ${failure.code}',
+          name: 'HealthPermissionNotifier',
+          stackTrace: failure.stackTrace,
+        );
+        state = AsyncValue.error(
+          failure,
+          failure.stackTrace ?? StackTrace.current,
+        );
+      },
+      (status) {
+        log('Permission status: $status', name: 'HealthPermissionNotifier');
+        state = AsyncValue.data(status);
+      },
+    );
+  }
+
+  Future<void> requestPermissions() async {
+    log('Requesting Health Connect permissions',
+        name: 'HealthPermissionNotifier');
+    state = const AsyncValue.loading();
+    final Either<Failure, HealthPermissionStatus> response =
+        await _healthRepository.requestPermissions();
+    response.fold(
+      (failure) {
+        log(
+          'Failed: $failure, Message: ${failure.message}, Code: ${failure.code}',
+          name: 'HealthPermissionNotifier',
+          stackTrace: failure.stackTrace,
+        );
+        state = AsyncValue.error(
+          failure,
+          failure.stackTrace ?? StackTrace.current,
+        );
+      },
+      (status) {
+        log('Permission status after request: $status',
+            name: 'HealthPermissionNotifier');
+        state = AsyncValue.data(status);
+      },
+    );
+  }
+}
+
+// ─── Summary data notifier ───────────────────────────────────────────────────
+
+/// Holds the aggregated [HealthSummary] read from Health Connect.
+@Riverpod(keepAlive: true)
+class HealthSummaryNotifier extends _$HealthSummaryNotifier {
+  late final HealthRepository _healthRepository;
+
+  @override
+  FutureOr<HealthSummary> build({
+    required HealthRepository healthRepository,
+  }) async {
+    _healthRepository = healthRepository;
+    return HealthSummary.empty;
+  }
+
+  Future<void> getHealthSummary() async {
+    log('Getting health summary', name: 'HealthSummaryNotifier');
+    state = const AsyncValue.loading();
+    final Either<Failure, HealthSummary> response =
+        await _healthRepository.getHealthSummary();
+    response.fold(
+      (failure) {
+        log(
+          'Failed: $failure, Message: ${failure.message}, Code: ${failure.code}',
+          name: 'HealthSummaryNotifier',
+          stackTrace: failure.stackTrace,
+        );
+        state = AsyncValue.error(
+          failure,
+          failure.stackTrace ?? StackTrace.current,
+        );
+      },
+      (summary) {
+        log('Health summary fetched', name: 'HealthSummaryNotifier');
+        state = AsyncValue.data(summary);
+      },
+    );
+  }
+}

--- a/lib/features/health_connect/providers/health_connect_notifier.g.dart
+++ b/lib/features/health_connect/providers/health_connect_notifier.g.dart
@@ -1,0 +1,353 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'health_connect_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$healthPermissionNotifierHash() =>
+    r'd3c27e05a3455ce83a41664ec42a50bd0368fe7e';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$HealthPermissionNotifier
+    extends BuildlessAsyncNotifier<HealthPermissionStatus> {
+  late final HealthRepository healthRepository;
+
+  FutureOr<HealthPermissionStatus> build({
+    required HealthRepository healthRepository,
+  });
+}
+
+/// Holds the Health Connect permission state, kept separate from the data
+/// notifier because permission and data have different lifecycles.
+///
+/// Copied from [HealthPermissionNotifier].
+@ProviderFor(HealthPermissionNotifier)
+const healthPermissionNotifierProvider = HealthPermissionNotifierFamily();
+
+/// Holds the Health Connect permission state, kept separate from the data
+/// notifier because permission and data have different lifecycles.
+///
+/// Copied from [HealthPermissionNotifier].
+class HealthPermissionNotifierFamily
+    extends Family<AsyncValue<HealthPermissionStatus>> {
+  /// Holds the Health Connect permission state, kept separate from the data
+  /// notifier because permission and data have different lifecycles.
+  ///
+  /// Copied from [HealthPermissionNotifier].
+  const HealthPermissionNotifierFamily();
+
+  /// Holds the Health Connect permission state, kept separate from the data
+  /// notifier because permission and data have different lifecycles.
+  ///
+  /// Copied from [HealthPermissionNotifier].
+  HealthPermissionNotifierProvider call({
+    required HealthRepository healthRepository,
+  }) {
+    return HealthPermissionNotifierProvider(healthRepository: healthRepository);
+  }
+
+  @override
+  HealthPermissionNotifierProvider getProviderOverride(
+    covariant HealthPermissionNotifierProvider provider,
+  ) {
+    return call(healthRepository: provider.healthRepository);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'healthPermissionNotifierProvider';
+}
+
+/// Holds the Health Connect permission state, kept separate from the data
+/// notifier because permission and data have different lifecycles.
+///
+/// Copied from [HealthPermissionNotifier].
+class HealthPermissionNotifierProvider
+    extends
+        AsyncNotifierProviderImpl<
+          HealthPermissionNotifier,
+          HealthPermissionStatus
+        > {
+  /// Holds the Health Connect permission state, kept separate from the data
+  /// notifier because permission and data have different lifecycles.
+  ///
+  /// Copied from [HealthPermissionNotifier].
+  HealthPermissionNotifierProvider({required HealthRepository healthRepository})
+    : this._internal(
+        () => HealthPermissionNotifier()..healthRepository = healthRepository,
+        from: healthPermissionNotifierProvider,
+        name: r'healthPermissionNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$healthPermissionNotifierHash,
+        dependencies: HealthPermissionNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            HealthPermissionNotifierFamily._allTransitiveDependencies,
+        healthRepository: healthRepository,
+      );
+
+  HealthPermissionNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.healthRepository,
+  }) : super.internal();
+
+  final HealthRepository healthRepository;
+
+  @override
+  FutureOr<HealthPermissionStatus> runNotifierBuild(
+    covariant HealthPermissionNotifier notifier,
+  ) {
+    return notifier.build(healthRepository: healthRepository);
+  }
+
+  @override
+  Override overrideWith(HealthPermissionNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: HealthPermissionNotifierProvider._internal(
+        () => create()..healthRepository = healthRepository,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        healthRepository: healthRepository,
+      ),
+    );
+  }
+
+  @override
+  AsyncNotifierProviderElement<HealthPermissionNotifier, HealthPermissionStatus>
+  createElement() {
+    return _HealthPermissionNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HealthPermissionNotifierProvider &&
+        other.healthRepository == healthRepository;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, healthRepository.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin HealthPermissionNotifierRef
+    on AsyncNotifierProviderRef<HealthPermissionStatus> {
+  /// The parameter `healthRepository` of this provider.
+  HealthRepository get healthRepository;
+}
+
+class _HealthPermissionNotifierProviderElement
+    extends
+        AsyncNotifierProviderElement<
+          HealthPermissionNotifier,
+          HealthPermissionStatus
+        >
+    with HealthPermissionNotifierRef {
+  _HealthPermissionNotifierProviderElement(super.provider);
+
+  @override
+  HealthRepository get healthRepository =>
+      (origin as HealthPermissionNotifierProvider).healthRepository;
+}
+
+String _$healthSummaryNotifierHash() =>
+    r'cce14160c3805569e37eb875e2c38ef48599b89e';
+
+abstract class _$HealthSummaryNotifier
+    extends BuildlessAsyncNotifier<HealthSummary> {
+  late final HealthRepository healthRepository;
+
+  FutureOr<HealthSummary> build({required HealthRepository healthRepository});
+}
+
+/// Holds the aggregated [HealthSummary] read from Health Connect.
+///
+/// Copied from [HealthSummaryNotifier].
+@ProviderFor(HealthSummaryNotifier)
+const healthSummaryNotifierProvider = HealthSummaryNotifierFamily();
+
+/// Holds the aggregated [HealthSummary] read from Health Connect.
+///
+/// Copied from [HealthSummaryNotifier].
+class HealthSummaryNotifierFamily extends Family<AsyncValue<HealthSummary>> {
+  /// Holds the aggregated [HealthSummary] read from Health Connect.
+  ///
+  /// Copied from [HealthSummaryNotifier].
+  const HealthSummaryNotifierFamily();
+
+  /// Holds the aggregated [HealthSummary] read from Health Connect.
+  ///
+  /// Copied from [HealthSummaryNotifier].
+  HealthSummaryNotifierProvider call({
+    required HealthRepository healthRepository,
+  }) {
+    return HealthSummaryNotifierProvider(healthRepository: healthRepository);
+  }
+
+  @override
+  HealthSummaryNotifierProvider getProviderOverride(
+    covariant HealthSummaryNotifierProvider provider,
+  ) {
+    return call(healthRepository: provider.healthRepository);
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'healthSummaryNotifierProvider';
+}
+
+/// Holds the aggregated [HealthSummary] read from Health Connect.
+///
+/// Copied from [HealthSummaryNotifier].
+class HealthSummaryNotifierProvider
+    extends AsyncNotifierProviderImpl<HealthSummaryNotifier, HealthSummary> {
+  /// Holds the aggregated [HealthSummary] read from Health Connect.
+  ///
+  /// Copied from [HealthSummaryNotifier].
+  HealthSummaryNotifierProvider({required HealthRepository healthRepository})
+    : this._internal(
+        () => HealthSummaryNotifier()..healthRepository = healthRepository,
+        from: healthSummaryNotifierProvider,
+        name: r'healthSummaryNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$healthSummaryNotifierHash,
+        dependencies: HealthSummaryNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            HealthSummaryNotifierFamily._allTransitiveDependencies,
+        healthRepository: healthRepository,
+      );
+
+  HealthSummaryNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.healthRepository,
+  }) : super.internal();
+
+  final HealthRepository healthRepository;
+
+  @override
+  FutureOr<HealthSummary> runNotifierBuild(
+    covariant HealthSummaryNotifier notifier,
+  ) {
+    return notifier.build(healthRepository: healthRepository);
+  }
+
+  @override
+  Override overrideWith(HealthSummaryNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: HealthSummaryNotifierProvider._internal(
+        () => create()..healthRepository = healthRepository,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        healthRepository: healthRepository,
+      ),
+    );
+  }
+
+  @override
+  AsyncNotifierProviderElement<HealthSummaryNotifier, HealthSummary>
+  createElement() {
+    return _HealthSummaryNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is HealthSummaryNotifierProvider &&
+        other.healthRepository == healthRepository;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, healthRepository.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin HealthSummaryNotifierRef on AsyncNotifierProviderRef<HealthSummary> {
+  /// The parameter `healthRepository` of this provider.
+  HealthRepository get healthRepository;
+}
+
+class _HealthSummaryNotifierProviderElement
+    extends AsyncNotifierProviderElement<HealthSummaryNotifier, HealthSummary>
+    with HealthSummaryNotifierRef {
+  _HealthSummaryNotifierProviderElement(super.provider);
+
+  @override
+  HealthRepository get healthRepository =>
+      (origin as HealthSummaryNotifierProvider).healthRepository;
+}
+
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/health_connect/repositories/health_repository.dart
+++ b/lib/features/health_connect/repositories/health_repository.dart
@@ -1,0 +1,68 @@
+import '../../../core/core.dart';
+import '../models/health_summary.dart';
+import '../services/health_connect_service.dart';
+
+/// Contract for reading health data and managing Health Connect permissions.
+///
+/// All methods return [FutureEither] — failures are surfaced as [Failure]
+/// rather than thrown, consistent with the rest of the app.
+abstract class HealthRepository {
+  /// Checks the current permission grant without prompting the user.
+  FutureEither<HealthPermissionStatus> checkPermissions();
+
+  /// Prompts the user to grant read access.
+  FutureEither<HealthPermissionStatus> requestPermissions();
+
+  /// Reads steps, heart rate, and blood oxygen into a single [HealthSummary].
+  FutureEither<HealthSummary> getHealthSummary();
+}
+
+class HealthRepositoryImpl implements HealthRepository {
+  final HealthConnectService _service;
+
+  HealthRepositoryImpl({required HealthConnectService service})
+      : _service = service;
+
+  @override
+  FutureEither<HealthPermissionStatus> checkPermissions() {
+    return futureHandler(() async {
+      final bool available = await _service.isAvailable();
+      if (!available) return HealthPermissionStatus.notAvailable;
+      final bool granted = await _service.hasPermissions();
+      return granted
+          ? HealthPermissionStatus.granted
+          : HealthPermissionStatus.denied;
+    });
+  }
+
+  @override
+  FutureEither<HealthPermissionStatus> requestPermissions() {
+    return futureHandler(() async {
+      final bool available = await _service.isAvailable();
+      if (!available) return HealthPermissionStatus.notAvailable;
+      final bool granted = await _service.requestPermissions();
+      return granted
+          ? HealthPermissionStatus.granted
+          : HealthPermissionStatus.denied;
+    });
+  }
+
+  @override
+  FutureEither<HealthSummary> getHealthSummary() {
+    return futureHandler(() async {
+      // Each metric is independent — a null/empty result for one simply
+      // propagates to the model rather than failing the whole summary.
+      final int? steps = await _service.getTodaySteps();
+      final heartRates = await _service.getHeartRates();
+      final bloodOxygen = await _service.getBloodOxygenReadings();
+
+      return HealthSummary(
+        stepsToday: steps,
+        latestHeartRate: heartRates.isNotEmpty ? heartRates.first : null,
+        latestBloodOxygen: bloodOxygen.isNotEmpty ? bloodOxygen.first : null,
+        recentHeartRates: heartRates,
+        recentBloodOxygenReadings: bloodOxygen,
+      );
+    });
+  }
+}

--- a/lib/features/health_connect/screens/health_screen.dart
+++ b/lib/features/health_connect/screens/health_screen.dart
@@ -1,0 +1,264 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+import 'package:intl/intl.dart';
+
+import '../../../components/components.dart';
+import '../../../core/core.dart';
+import '../health_connect.dart';
+
+@RoutePage(name: HealthScreen.name)
+class HealthScreen extends ConsumerStatefulWidget {
+  static const String path = "/health";
+  static const String name = "HealthScreen";
+
+  const HealthScreen({super.key});
+
+  @override
+  ConsumerState<HealthScreen> createState() => _HealthScreenState();
+}
+
+class _HealthScreenState extends ConsumerState<HealthScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final HealthPermissionStatus? status =
+          ref.read(healthPermissionNotifierProviderImpl).value;
+      if (status == HealthPermissionStatus.granted) {
+        await ref
+            .read(healthSummaryNotifierProviderImpl.notifier)
+            .getHealthSummary();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final AsyncValue<HealthPermissionStatus> permissionAsync =
+        ref.watch(healthPermissionNotifierProviderImpl);
+    final AsyncValue<HealthSummary> summaryAsync =
+        ref.watch(healthSummaryNotifierProviderImpl);
+
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: kPadding16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const CustomAppBar(pageTitle: "Health"),
+              permissionAsync.when(
+                loading: () => const Padding(
+                  padding: EdgeInsets.only(top: kPadding64),
+                  child: Center(child: CircularProgressIndicator.adaptive()),
+                ),
+                error: (error, _) => _buildMessage(
+                  theme,
+                  "Something went wrong while checking Health Connect.",
+                ),
+                data: (status) {
+                  switch (status) {
+                    case HealthPermissionStatus.notAvailable:
+                      return _buildMessage(
+                        theme,
+                        "Health Connect is not available on this device.",
+                      );
+                    case HealthPermissionStatus.granted:
+                      return summaryAsync.when(
+                        loading: () => const Padding(
+                          padding: EdgeInsets.only(top: kPadding64),
+                          child: Center(
+                            child: CircularProgressIndicator.adaptive(),
+                          ),
+                        ),
+                        error: (error, _) => _buildMessage(
+                          theme,
+                          "Could not load your health data.",
+                        ),
+                        data: (summary) => _buildData(theme, summary),
+                      );
+                    case HealthPermissionStatus.unknown:
+                    case HealthPermissionStatus.denied:
+                      return _buildPermissionRequest(theme);
+                  }
+                },
+              ),
+              const SizedBox(height: kPadding64 * 2),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMessage(ThemeData theme, String message) => Padding(
+        padding: const EdgeInsets.only(top: kPadding64),
+        child: Center(
+          child: Text(
+            message,
+            style: theme.textTheme.bodyLarge!
+                .copyWith(color: AppColours.neutral50),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+
+  Widget _buildPermissionRequest(ThemeData theme) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text("Connect your health data", style: theme.textTheme.titleLarge),
+          const Gap(kPadding8),
+          Text(
+            "Allow Circle to read your steps, heart rate, and blood oxygen "
+            "from Health Connect to keep track of your wellbeing.",
+            style: theme.textTheme.bodyMedium!
+                .copyWith(color: AppColours.neutral50),
+          ),
+          const Gap(kPadding24),
+          AppButton(
+            label: "Grant Health Connect Access",
+            onPressed: () => ref
+                .read(healthPermissionNotifierProviderImpl.notifier)
+                .requestPermissions(),
+          ),
+        ],
+      );
+
+  Widget _buildData(ThemeData theme, HealthSummary summary) {
+    final DateFormat formatter = DateFormat('h:mm a');
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // ── Steps ──────────────────────────────────────────────────────────
+        const _SectionHeader(
+          icon: FluentIcons.person_walking_24_regular,
+          title: "Steps Today",
+        ),
+        const Gap(kPadding8),
+        Text(
+          summary.stepsToday != null ? "${summary.stepsToday}" : "No data",
+          style: theme.textTheme.displaySmall!
+              .copyWith(fontWeight: FontWeight.w700),
+        ),
+        const Gap(kPadding32),
+
+        // ── Heart rate ─────────────────────────────────────────────────────
+        const _SectionHeader(
+          icon: FluentIcons.heart_pulse_24_regular,
+          title: "Heart Rate",
+        ),
+        const Gap(kPadding8),
+        if (summary.latestHeartRate != null) ...[
+          Text(
+            "${summary.latestHeartRate!.bpm} bpm",
+            style: theme.textTheme.headlineSmall!
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+          Text(
+            "Last reading ${formatter.format(summary.latestHeartRate!.timestamp)}",
+            style: theme.textTheme.bodySmall!
+                .copyWith(color: AppColours.neutral50),
+          ),
+        ] else
+          Text("No data", style: theme.textTheme.bodyMedium),
+        const Gap(kPadding16),
+        ...summary.recentHeartRates.take(10).map(
+              (record) => _ReadingTile(
+                timestamp: record.timestamp,
+                value: "${record.bpm} bpm",
+                formatter: formatter,
+              ),
+            ),
+        const Gap(kPadding32),
+
+        // ── Blood oxygen ───────────────────────────────────────────────────
+        const _SectionHeader(
+          icon: FluentIcons.drop_24_regular,
+          title: "Blood Oxygen (SpO2)",
+        ),
+        const Gap(kPadding8),
+        if (summary.latestBloodOxygen != null) ...[
+          Text(
+            "${summary.latestBloodOxygen!.percentage.toStringAsFixed(1)}%",
+            style: theme.textTheme.headlineSmall!
+                .copyWith(fontWeight: FontWeight.w700),
+          ),
+          Text(
+            "Last reading ${formatter.format(summary.latestBloodOxygen!.timestamp)}",
+            style: theme.textTheme.bodySmall!
+                .copyWith(color: AppColours.neutral50),
+          ),
+        ] else
+          Text("No data", style: theme.textTheme.bodyMedium),
+        const Gap(kPadding16),
+        ...summary.recentBloodOxygenReadings.take(10).map(
+              (record) => _ReadingTile(
+                timestamp: record.timestamp,
+                value: "${record.percentage.toStringAsFixed(1)}%",
+                formatter: formatter,
+              ),
+            ),
+      ],
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  const _SectionHeader({required this.icon, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      children: [
+        Icon(icon, color: theme.colorScheme.primary),
+        const Gap(kPadding8),
+        Text(title, style: theme.textTheme.titleMedium),
+      ],
+    );
+  }
+}
+
+class _ReadingTile extends StatelessWidget {
+  final DateTime timestamp;
+  final String value;
+  final DateFormat formatter;
+
+  const _ReadingTile({
+    required this.timestamp,
+    required this.value,
+    required this.formatter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool isDarkMode = theme.brightness == Brightness.dark;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: kPadding8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: kPadding16,
+          vertical: kPadding12,
+        ),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(kPadding12),
+          color: isDarkMode ? AppColours.neutral10 : AppColours.neutral95,
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(formatter.format(timestamp), style: theme.textTheme.bodyMedium),
+            Text(value, style: theme.textTheme.titleSmall),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/health_connect/services/health_connect_service.dart
+++ b/lib/features/health_connect/services/health_connect_service.dart
@@ -1,0 +1,166 @@
+import 'dart:developer';
+
+import 'package:health/health.dart';
+
+import '../../../core/error/exceptions.dart';
+import '../models/health_record.dart';
+
+/// The data types this feature reads. Central list — add or remove a type
+/// here and the request/check/fetch logic follows automatically.
+const List<HealthDataType> _kHealthTypes = [
+  HealthDataType.STEPS,
+  HealthDataType.HEART_RATE,
+  HealthDataType.BLOOD_OXYGEN,
+];
+
+/// Low-level I/O with the `health` package (Health Connect on Android,
+/// HealthKit on iOS). Contains no business logic — it only talks to the
+/// platform and maps raw data points onto the feature's models.
+class HealthConnectService {
+  final Health _health = Health();
+
+  /// `configure()` must run once before any other call. Tracked so repeated
+  /// service calls don't reconfigure unnecessarily.
+  bool _isConfigured = false;
+
+  Future<void> _ensureConfigured() async {
+    if (_isConfigured) return;
+    await _health.configure();
+    _isConfigured = true;
+  }
+
+  /// Whether Health Connect (Android) / HealthKit (iOS) is available on this
+  /// device. Returns false rather than throwing so the caller can branch to a
+  /// "not available" state.
+  Future<bool> isAvailable() async {
+    try {
+      await _ensureConfigured();
+      return await _health.isHealthConnectAvailable();
+    } catch (e, stack) {
+      log('isAvailable failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      return false;
+    }
+  }
+
+  /// Checks whether read permissions are already granted, without prompting.
+  Future<bool> hasPermissions() async {
+    try {
+      await _ensureConfigured();
+      final result = await _health.hasPermissions(_kHealthTypes);
+      return result ?? false;
+    } catch (e, stack) {
+      log('hasPermissions failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      return false;
+    }
+  }
+
+  /// Prompts the user to grant read access to [_kHealthTypes].
+  /// Returns true when access is granted.
+  Future<bool> requestPermissions() async {
+    try {
+      await _ensureConfigured();
+      return await _health.requestAuthorization(_kHealthTypes);
+    } catch (e, stack) {
+      log('requestPermissions failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      throw AppException(
+        message: 'Could not request Health Connect permissions',
+        debugMessage: e.toString(),
+        stackTrace: stack,
+      );
+    }
+  }
+
+  /// Returns today's total step count, or null when no data is available.
+  Future<int?> getTodaySteps() async {
+    try {
+      await _ensureConfigured();
+      final DateTime now = DateTime.now();
+      final DateTime startOfDay = DateTime(now.year, now.month, now.day);
+      return await _health.getTotalStepsInInterval(startOfDay, now);
+    } catch (e, stack) {
+      log('getTodaySteps failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      throw AppException(
+        message: 'Failed to fetch step count',
+        debugMessage: e.toString(),
+        stackTrace: stack,
+      );
+    }
+  }
+
+  /// Returns heart rate readings from the last [hours] hours, newest first.
+  Future<List<HeartRateRecord>> getHeartRates({int hours = 24}) async {
+    try {
+      await _ensureConfigured();
+      final DateTime end = DateTime.now();
+      final DateTime start = end.subtract(Duration(hours: hours));
+      final List<HealthDataPoint> points = await _health.getHealthDataFromTypes(
+        types: const [HealthDataType.HEART_RATE],
+        startTime: start,
+        endTime: end,
+      );
+      final records = points
+          .map(
+            (point) => HeartRateRecord(
+              timestamp: point.dateFrom,
+              bpm: (point.value as NumericHealthValue).numericValue.round(),
+            ),
+          )
+          .toList()
+        ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+      return records;
+    } catch (e, stack) {
+      log('getHeartRates failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      throw AppException(
+        message: 'Failed to fetch heart rate data',
+        debugMessage: e.toString(),
+        stackTrace: stack,
+      );
+    }
+  }
+
+  /// Returns blood oxygen (SpO2) readings from the last [hours] hours,
+  /// newest first.
+  Future<List<BloodOxygenRecord>> getBloodOxygenReadings({
+    int hours = 24,
+  }) async {
+    try {
+      await _ensureConfigured();
+      final DateTime end = DateTime.now();
+      final DateTime start = end.subtract(Duration(hours: hours));
+      final List<HealthDataPoint> points = await _health.getHealthDataFromTypes(
+        types: const [HealthDataType.BLOOD_OXYGEN],
+        startTime: start,
+        endTime: end,
+      );
+      final records = points
+          .map(
+            (point) => BloodOxygenRecord(
+              timestamp: point.dateFrom,
+              percentage: _normalizeOxygen(
+                (point.value as NumericHealthValue).numericValue.toDouble(),
+              ),
+            ),
+          )
+          .toList()
+        ..sort((a, b) => b.timestamp.compareTo(a.timestamp));
+      return records;
+    } catch (e, stack) {
+      log('getBloodOxygenReadings failed', error: e, stackTrace: stack,
+          name: 'HealthConnectService');
+      throw AppException(
+        message: 'Failed to fetch SpO2 data',
+        debugMessage: e.toString(),
+        stackTrace: stack,
+      );
+    }
+  }
+
+  /// Health Connect reports SpO2 as a percentage (e.g. 98.0) while HealthKit
+  /// reports a fraction (e.g. 0.98). Normalize both to a 0–100 percentage.
+  double _normalizeOxygen(double raw) => raw <= 1 ? raw * 100 : raw;
+}

--- a/lib/features/home/screens/components/components.dart
+++ b/lib/features/home/screens/components/components.dart
@@ -3,3 +3,4 @@ export 'emergency_sharing_card.dart';
 export 'meds_reminder_item.dart';
 export 'meds_reminder_card.dart';
 export 'water_card.dart';
+export 'health_summary_card.dart';

--- a/lib/features/home/screens/components/health_summary_card.dart
+++ b/lib/features/home/screens/components/health_summary_card.dart
@@ -1,0 +1,227 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+
+import '../../../../core/core.dart';
+import '../../../health_connect/health_connect.dart';
+
+/// Home-screen card summarising the latest Health Connect metrics.
+///
+/// Lives alongside [WaterCard] in the home feature because it is a home
+/// dashboard element. It watches the health providers directly and adapts to
+/// the permission state.
+class HealthSummaryCard extends ConsumerWidget {
+  final VoidCallback onPressed;
+
+  const HealthSummaryCard({super.key, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final bool isDarkMode = theme.brightness == Brightness.dark;
+
+    final AsyncValue<HealthPermissionStatus> permissionAsync =
+        ref.watch(healthPermissionNotifierProviderImpl);
+    final AsyncValue<HealthSummary> summaryAsync =
+        ref.watch(healthSummaryNotifierProviderImpl);
+
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: BorderRadius.circular(24),
+      splashFactory: InkSparkle.splashFactory,
+      splashColor: theme.colorScheme.primary.withValues(alpha: .2),
+      child: Ink(
+        padding: const EdgeInsets.all(kPadding16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(24),
+          border: Border.all(
+            color: isDarkMode ? AppColours.neutral10 : AppColours.neutral95,
+          ),
+        ),
+        child: permissionAsync.when(
+          loading: () => const _CardMessage(message: null),
+          error: (_, __) =>
+              const _CardMessage(message: "Couldn't load health data"),
+          data: (status) {
+            switch (status) {
+              case HealthPermissionStatus.notAvailable:
+                return const _CardMessage(
+                  message: "Health Connect is not available on this device",
+                );
+              case HealthPermissionStatus.granted:
+                return summaryAsync.when(
+                  loading: () => const _CardMessage(message: null),
+                  error: (_, __) =>
+                      const _CardMessage(message: "Couldn't load health data"),
+                  data: (summary) => _CardData(
+                    summary: summary,
+                    theme: theme,
+                  ),
+                );
+              case HealthPermissionStatus.unknown:
+              case HealthPermissionStatus.denied:
+                return _CardPermissionRequest(
+                  theme: theme,
+                  onRequest: () => ref
+                      .read(healthPermissionNotifierProviderImpl.notifier)
+                      .requestPermissions(),
+                );
+            }
+          },
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows a centred message, or a spinner when [message] is null.
+class _CardMessage extends StatelessWidget {
+  final String? message;
+  const _CardMessage({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return SizedBox(
+      height: 72,
+      child: Center(
+        child: message == null
+            ? const CircularProgressIndicator.adaptive()
+            : Text(
+                message!,
+                style: theme.textTheme.bodySmall!
+                    .copyWith(color: AppColours.neutral50),
+                textAlign: TextAlign.center,
+              ),
+      ),
+    );
+  }
+}
+
+class _CardPermissionRequest extends StatelessWidget {
+  final ThemeData theme;
+  final VoidCallback onRequest;
+  const _CardPermissionRequest({required this.theme, required this.onRequest});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Icon(FluentIcons.heart_pulse_24_regular,
+                color: theme.colorScheme.primary),
+            const Gap(kPadding4),
+            Text(
+              "Health",
+              style: theme.textTheme.bodyLarge!
+                  .copyWith(color: theme.colorScheme.primary),
+            ),
+          ],
+        ),
+        const Gap(kPadding8),
+        Text(
+          "Connect Health Connect to see your steps, heart rate, and SpO2.",
+          style:
+              theme.textTheme.bodySmall!.copyWith(color: AppColours.neutral50),
+        ),
+        const Gap(kPadding12),
+        TextButton(
+          onPressed: onRequest,
+          style: TextButton.styleFrom(padding: EdgeInsets.zero),
+          child: const Text("Grant Access"),
+        ),
+      ],
+    );
+  }
+}
+
+class _CardData extends StatelessWidget {
+  final HealthSummary summary;
+  final ThemeData theme;
+  const _CardData({required this.summary, required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          children: [
+            Icon(FluentIcons.heart_pulse_24_regular,
+                color: theme.colorScheme.primary),
+            const Gap(kPadding4),
+            Text(
+              "Health",
+              style: theme.textTheme.bodyLarge!
+                  .copyWith(color: theme.colorScheme.primary),
+            ),
+          ],
+        ),
+        const Gap(kPadding16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            _MetricChip(
+              icon: FluentIcons.person_walking_24_regular,
+              label: "Steps",
+              value: summary.stepsToday != null ? "${summary.stepsToday}" : "--",
+              theme: theme,
+            ),
+            _MetricChip(
+              icon: FluentIcons.heart_pulse_24_regular,
+              label: "Heart Rate",
+              value: summary.latestHeartRate != null
+                  ? "${summary.latestHeartRate!.bpm} bpm"
+                  : "--",
+              theme: theme,
+            ),
+            _MetricChip(
+              icon: FluentIcons.drop_24_regular,
+              label: "SpO2",
+              value: summary.latestBloodOxygen != null
+                  ? "${summary.latestBloodOxygen!.percentage.toStringAsFixed(1)}%"
+                  : "--",
+              theme: theme,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MetricChip extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+  final ThemeData theme;
+
+  const _MetricChip({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.theme,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 20, color: theme.colorScheme.primary),
+        const Gap(kPadding4),
+        Text(value, style: theme.textTheme.titleSmall),
+        Text(
+          label,
+          style:
+              theme.textTheme.bodySmall!.copyWith(color: AppColours.neutral50),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -6,6 +8,7 @@ import 'package:gap/gap.dart';
 import '../../../core/core.dart';
 import '../../auth/auth.dart';
 import '../../emergency/emergency.dart';
+import '../../health_connect/health_connect.dart';
 import '../../profile/profile.dart';
 import '../../water/water.dart';
 import '../home.dart';
@@ -28,6 +31,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       await ref.watch(userNotifierProviderImpl.notifier).getSelfUserData();
       await ref.watch(waterLogNotifierProviderIml.notifier).getWaterLogs();
       await ref.watch(waterPrefsNotifierProviderImpl.notifier).getWaterPreferences();
+
+      // Health Connect — check permissions, then fetch data only if granted.
+      // Fetched without awaiting so it doesn't delay the rest of the dashboard.
+      await ref
+          .read(healthPermissionNotifierProviderImpl.notifier)
+          .checkPermissions();
+      if (ref.read(healthPermissionNotifierProviderImpl).value ==
+          HealthPermissionStatus.granted) {
+        unawaited(ref
+            .read(healthSummaryNotifierProviderImpl.notifier)
+            .getHealthSummary());
+      }
     });
     super.initState();
   }
@@ -114,6 +129,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 alignment: Alignment.centerLeft,
                 child: Text("Your Health Info",
                     style: theme.textTheme.titleMedium),
+              ),
+              const Gap(kPadding16),
+              HealthSummaryCard(
+                onPressed: () {
+                  context.router.pushNamed(HealthScreen.path);
+                },
               ),
               // const Gap(kPadding16),
               // GestureDetector(

--- a/lib/features/meds/providers/med_notifier.g.dart
+++ b/lib/features/meds/providers/med_notifier.g.dart
@@ -32,9 +32,7 @@ class _SystemHash {
 abstract class _$MedNotifier extends BuildlessAsyncNotifier<List<Medication>> {
   late final MedRepository medRepository;
 
-  FutureOr<List<Medication>> build({
-    required MedRepository medRepository,
-  });
+  FutureOr<List<Medication>> build({required MedRepository medRepository});
 }
 
 /// See also [MedNotifier].
@@ -47,21 +45,15 @@ class MedNotifierFamily extends Family<AsyncValue<List<Medication>>> {
   const MedNotifierFamily();
 
   /// See also [MedNotifier].
-  MedNotifierProvider call({
-    required MedRepository medRepository,
-  }) {
-    return MedNotifierProvider(
-      medRepository: medRepository,
-    );
+  MedNotifierProvider call({required MedRepository medRepository}) {
+    return MedNotifierProvider(medRepository: medRepository);
   }
 
   @override
   MedNotifierProvider getProviderOverride(
     covariant MedNotifierProvider provider,
   ) {
-    return call(
-      medRepository: provider.medRepository,
-    );
+    return call(medRepository: provider.medRepository);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -83,21 +75,19 @@ class MedNotifierFamily extends Family<AsyncValue<List<Medication>>> {
 class MedNotifierProvider
     extends AsyncNotifierProviderImpl<MedNotifier, List<Medication>> {
   /// See also [MedNotifier].
-  MedNotifierProvider({
-    required MedRepository medRepository,
-  }) : this._internal(
-          () => MedNotifier()..medRepository = medRepository,
-          from: medNotifierProvider,
-          name: r'medNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$medNotifierHash,
-          dependencies: MedNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              MedNotifierFamily._allTransitiveDependencies,
-          medRepository: medRepository,
-        );
+  MedNotifierProvider({required MedRepository medRepository})
+    : this._internal(
+        () => MedNotifier()..medRepository = medRepository,
+        from: medNotifierProvider,
+        name: r'medNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$medNotifierHash,
+        dependencies: MedNotifierFamily._dependencies,
+        allTransitiveDependencies: MedNotifierFamily._allTransitiveDependencies,
+        medRepository: medRepository,
+      );
 
   MedNotifierProvider._internal(
     super._createNotifier, {
@@ -112,12 +102,8 @@ class MedNotifierProvider
   final MedRepository medRepository;
 
   @override
-  FutureOr<List<Medication>> runNotifierBuild(
-    covariant MedNotifier notifier,
-  ) {
-    return notifier.build(
-      medRepository: medRepository,
-    );
+  FutureOr<List<Medication>> runNotifierBuild(covariant MedNotifier notifier) {
+    return notifier.build(medRepository: medRepository);
   }
 
   @override
@@ -171,5 +157,6 @@ class _MedNotifierProviderElement
   MedRepository get medRepository =>
       (origin as MedNotifierProvider).medRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/meds/providers/med_scheduled_doses_notifier.g.dart
+++ b/lib/features/meds/providers/med_scheduled_doses_notifier.g.dart
@@ -88,28 +88,33 @@ class MedScheduledDosesNotifierFamily
 }
 
 /// See also [MedScheduledDosesNotifier].
-class MedScheduledDosesNotifierProvider extends AsyncNotifierProviderImpl<
-    MedScheduledDosesNotifier, List<ScheduledDose>> {
+class MedScheduledDosesNotifierProvider
+    extends
+        AsyncNotifierProviderImpl<
+          MedScheduledDosesNotifier,
+          List<ScheduledDose>
+        > {
   /// See also [MedScheduledDosesNotifier].
   MedScheduledDosesNotifierProvider({
     required MedRepository medRepository,
     required NotificationRepository notificationRepository,
   }) : this._internal(
-          () => MedScheduledDosesNotifier()
-            ..medRepository = medRepository
-            ..notificationRepository = notificationRepository,
-          from: medScheduledDosesNotifierProvider,
-          name: r'medScheduledDosesNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$medScheduledDosesNotifierHash,
-          dependencies: MedScheduledDosesNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              MedScheduledDosesNotifierFamily._allTransitiveDependencies,
-          medRepository: medRepository,
-          notificationRepository: notificationRepository,
-        );
+         () =>
+             MedScheduledDosesNotifier()
+               ..medRepository = medRepository
+               ..notificationRepository = notificationRepository,
+         from: medScheduledDosesNotifierProvider,
+         name: r'medScheduledDosesNotifierProvider',
+         debugGetCreateSourceHash:
+             const bool.fromEnvironment('dart.vm.product')
+                 ? null
+                 : _$medScheduledDosesNotifierHash,
+         dependencies: MedScheduledDosesNotifierFamily._dependencies,
+         allTransitiveDependencies:
+             MedScheduledDosesNotifierFamily._allTransitiveDependencies,
+         medRepository: medRepository,
+         notificationRepository: notificationRepository,
+       );
 
   MedScheduledDosesNotifierProvider._internal(
     super._createNotifier, {
@@ -140,9 +145,10 @@ class MedScheduledDosesNotifierProvider extends AsyncNotifierProviderImpl<
     return ProviderOverride(
       origin: this,
       override: MedScheduledDosesNotifierProvider._internal(
-        () => create()
-          ..medRepository = medRepository
-          ..notificationRepository = notificationRepository,
+        () =>
+            create()
+              ..medRepository = medRepository
+              ..notificationRepository = notificationRepository,
         from: from,
         name: null,
         dependencies: null,
@@ -156,7 +162,7 @@ class MedScheduledDosesNotifierProvider extends AsyncNotifierProviderImpl<
 
   @override
   AsyncNotifierProviderElement<MedScheduledDosesNotifier, List<ScheduledDose>>
-      createElement() {
+  createElement() {
     return _MedScheduledDosesNotifierProviderElement(this);
   }
 
@@ -189,8 +195,12 @@ mixin MedScheduledDosesNotifierRef
 }
 
 class _MedScheduledDosesNotifierProviderElement
-    extends AsyncNotifierProviderElement<MedScheduledDosesNotifier,
-        List<ScheduledDose>> with MedScheduledDosesNotifierRef {
+    extends
+        AsyncNotifierProviderElement<
+          MedScheduledDosesNotifier,
+          List<ScheduledDose>
+        >
+    with MedScheduledDosesNotifierRef {
   _MedScheduledDosesNotifierProviderElement(super.provider);
 
   @override
@@ -200,5 +210,6 @@ class _MedScheduledDosesNotifierProviderElement
   NotificationRepository get notificationRepository =>
       (origin as MedScheduledDosesNotifierProvider).notificationRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/water/providers/water_log_notifier.dart
+++ b/lib/features/water/providers/water_log_notifier.dart
@@ -73,6 +73,9 @@ class WaterLogNotifier extends _$WaterLogNotifier {
   }
 
   double calculateTotalFromLogs({List<WaterLog>? logs}) {
+    if (state.value == null) {
+      return 0.0;
+    }
     List<WaterLog> allLogs = logs ?? state.value!;
     double totalToday = 0;
     //Calculate total

--- a/lib/features/water/providers/water_log_notifier.g.dart
+++ b/lib/features/water/providers/water_log_notifier.g.dart
@@ -33,9 +33,7 @@ abstract class _$WaterLogNotifier
     extends BuildlessAsyncNotifier<List<WaterLog>> {
   late final WaterRepository waterRepository;
 
-  FutureOr<List<WaterLog>> build({
-    required WaterRepository waterRepository,
-  });
+  FutureOr<List<WaterLog>> build({required WaterRepository waterRepository});
 }
 
 /// See also [WaterLogNotifier].
@@ -48,21 +46,15 @@ class WaterLogNotifierFamily extends Family<AsyncValue<List<WaterLog>>> {
   const WaterLogNotifierFamily();
 
   /// See also [WaterLogNotifier].
-  WaterLogNotifierProvider call({
-    required WaterRepository waterRepository,
-  }) {
-    return WaterLogNotifierProvider(
-      waterRepository: waterRepository,
-    );
+  WaterLogNotifierProvider call({required WaterRepository waterRepository}) {
+    return WaterLogNotifierProvider(waterRepository: waterRepository);
   }
 
   @override
   WaterLogNotifierProvider getProviderOverride(
     covariant WaterLogNotifierProvider provider,
   ) {
-    return call(
-      waterRepository: provider.waterRepository,
-    );
+    return call(waterRepository: provider.waterRepository);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -84,21 +76,20 @@ class WaterLogNotifierFamily extends Family<AsyncValue<List<WaterLog>>> {
 class WaterLogNotifierProvider
     extends AsyncNotifierProviderImpl<WaterLogNotifier, List<WaterLog>> {
   /// See also [WaterLogNotifier].
-  WaterLogNotifierProvider({
-    required WaterRepository waterRepository,
-  }) : this._internal(
-          () => WaterLogNotifier()..waterRepository = waterRepository,
-          from: waterLogNotifierProvider,
-          name: r'waterLogNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$waterLogNotifierHash,
-          dependencies: WaterLogNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              WaterLogNotifierFamily._allTransitiveDependencies,
-          waterRepository: waterRepository,
-        );
+  WaterLogNotifierProvider({required WaterRepository waterRepository})
+    : this._internal(
+        () => WaterLogNotifier()..waterRepository = waterRepository,
+        from: waterLogNotifierProvider,
+        name: r'waterLogNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$waterLogNotifierHash,
+        dependencies: WaterLogNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            WaterLogNotifierFamily._allTransitiveDependencies,
+        waterRepository: waterRepository,
+      );
 
   WaterLogNotifierProvider._internal(
     super._createNotifier, {
@@ -116,9 +107,7 @@ class WaterLogNotifierProvider
   FutureOr<List<WaterLog>> runNotifierBuild(
     covariant WaterLogNotifier notifier,
   ) {
-    return notifier.build(
-      waterRepository: waterRepository,
-    );
+    return notifier.build(waterRepository: waterRepository);
   }
 
   @override
@@ -139,7 +128,7 @@ class WaterLogNotifierProvider
 
   @override
   AsyncNotifierProviderElement<WaterLogNotifier, List<WaterLog>>
-      createElement() {
+  createElement() {
     return _WaterLogNotifierProviderElement(this);
   }
 
@@ -174,5 +163,6 @@ class _WaterLogNotifierProviderElement
   WaterRepository get waterRepository =>
       (origin as WaterLogNotifierProvider).waterRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/features/water/providers/water_prefs_notifier.g.dart
+++ b/lib/features/water/providers/water_prefs_notifier.g.dart
@@ -34,9 +34,7 @@ abstract class _$WaterPrefsNotifier
     extends BuildlessAsyncNotifier<WaterPreferences> {
   late final WaterRepository waterRepository;
 
-  FutureOr<WaterPreferences> build({
-    required WaterRepository waterRepository,
-  });
+  FutureOr<WaterPreferences> build({required WaterRepository waterRepository});
 }
 
 /// See also [WaterPrefsNotifier].
@@ -49,21 +47,15 @@ class WaterPrefsNotifierFamily extends Family<AsyncValue<WaterPreferences>> {
   const WaterPrefsNotifierFamily();
 
   /// See also [WaterPrefsNotifier].
-  WaterPrefsNotifierProvider call({
-    required WaterRepository waterRepository,
-  }) {
-    return WaterPrefsNotifierProvider(
-      waterRepository: waterRepository,
-    );
+  WaterPrefsNotifierProvider call({required WaterRepository waterRepository}) {
+    return WaterPrefsNotifierProvider(waterRepository: waterRepository);
   }
 
   @override
   WaterPrefsNotifierProvider getProviderOverride(
     covariant WaterPrefsNotifierProvider provider,
   ) {
-    return call(
-      waterRepository: provider.waterRepository,
-    );
+    return call(waterRepository: provider.waterRepository);
   }
 
   static const Iterable<ProviderOrFamily>? _dependencies = null;
@@ -85,21 +77,20 @@ class WaterPrefsNotifierFamily extends Family<AsyncValue<WaterPreferences>> {
 class WaterPrefsNotifierProvider
     extends AsyncNotifierProviderImpl<WaterPrefsNotifier, WaterPreferences> {
   /// See also [WaterPrefsNotifier].
-  WaterPrefsNotifierProvider({
-    required WaterRepository waterRepository,
-  }) : this._internal(
-          () => WaterPrefsNotifier()..waterRepository = waterRepository,
-          from: waterPrefsNotifierProvider,
-          name: r'waterPrefsNotifierProvider',
-          debugGetCreateSourceHash:
-              const bool.fromEnvironment('dart.vm.product')
-                  ? null
-                  : _$waterPrefsNotifierHash,
-          dependencies: WaterPrefsNotifierFamily._dependencies,
-          allTransitiveDependencies:
-              WaterPrefsNotifierFamily._allTransitiveDependencies,
-          waterRepository: waterRepository,
-        );
+  WaterPrefsNotifierProvider({required WaterRepository waterRepository})
+    : this._internal(
+        () => WaterPrefsNotifier()..waterRepository = waterRepository,
+        from: waterPrefsNotifierProvider,
+        name: r'waterPrefsNotifierProvider',
+        debugGetCreateSourceHash:
+            const bool.fromEnvironment('dart.vm.product')
+                ? null
+                : _$waterPrefsNotifierHash,
+        dependencies: WaterPrefsNotifierFamily._dependencies,
+        allTransitiveDependencies:
+            WaterPrefsNotifierFamily._allTransitiveDependencies,
+        waterRepository: waterRepository,
+      );
 
   WaterPrefsNotifierProvider._internal(
     super._createNotifier, {
@@ -117,9 +108,7 @@ class WaterPrefsNotifierProvider
   FutureOr<WaterPreferences> runNotifierBuild(
     covariant WaterPrefsNotifier notifier,
   ) {
-    return notifier.build(
-      waterRepository: waterRepository,
-    );
+    return notifier.build(waterRepository: waterRepository);
   }
 
   @override
@@ -140,7 +129,7 @@ class WaterPrefsNotifierProvider
 
   @override
   AsyncNotifierProviderElement<WaterPrefsNotifier, WaterPreferences>
-      createElement() {
+  createElement() {
     return _WaterPrefsNotifierProviderElement(this);
   }
 
@@ -175,5 +164,6 @@ class _WaterPrefsNotifierProviderElement
   WaterRepository get waterRepository =>
       (origin as WaterPrefsNotifierProvider).waterRepository;
 }
+
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/gen/assets.gen.dart
+++ b/lib/gen/assets.gen.dart
@@ -66,21 +66,21 @@ class $AssetsFontsGen {
 
   /// List of all assets
   List<String> get values => [
-        plusJakartaSansBold,
-        plusJakartaSansBoldItalic,
-        plusJakartaSansExtraBold,
-        plusJakartaSansExtraBoldItalic,
-        plusJakartaSansExtraLight,
-        plusJakartaSansExtraLightItalic,
-        plusJakartaSansItalic,
-        plusJakartaSansLight,
-        plusJakartaSansLightItalic,
-        plusJakartaSansMedium,
-        plusJakartaSansMediumItalic,
-        plusJakartaSansRegular,
-        plusJakartaSansSemiBold,
-        plusJakartaSansSemiBoldItalic
-      ];
+    plusJakartaSansBold,
+    plusJakartaSansBoldItalic,
+    plusJakartaSansExtraBold,
+    plusJakartaSansExtraBoldItalic,
+    plusJakartaSansExtraLight,
+    plusJakartaSansExtraLightItalic,
+    plusJakartaSansItalic,
+    plusJakartaSansLight,
+    plusJakartaSansLightItalic,
+    plusJakartaSansMedium,
+    plusJakartaSansMediumItalic,
+    plusJakartaSansRegular,
+    plusJakartaSansSemiBold,
+    plusJakartaSansSemiBoldItalic,
+  ];
 }
 
 class $AssetsImagesGen {
@@ -312,76 +312,76 @@ class $AssetsSvgGen {
 
   /// List of all assets
   List<String> get values => [
-        apple,
-        arrowLeft,
-        arrowRight,
-        bottle,
-        cake,
-        calendarFilled,
-        calendar,
-        check,
-        chevronBack,
-        chevronDown,
-        chevronLeft,
-        chevronRight,
-        chevronUp,
-        clockFilled,
-        clock,
-        cross,
-        cupFiiled,
-        cup,
-        deleteFilled,
-        delete,
-        detailsFilled,
-        details,
-        distance,
-        dna,
-        dropletAltFilled,
-        dropletAlt,
-        dropletFilled,
-        droplet,
-        edit,
-        emergencyAltFilled,
-        emergencyAlt,
-        emergency,
-        eyeOff,
-        eye,
-        filter,
-        google,
-        googleLogoColor,
-        heartFilled,
-        heart,
-        homeAltFilled,
-        homeAlt,
-        homeFilled,
-        home,
-        locationFilled,
-        locationOffFilled,
-        locationOff,
-        location,
-        logOut,
-        medicationFilled,
-        medication,
-        moonFilled,
-        moon,
-        peopleFilled,
-        people,
-        phoneFilled,
-        phone,
-        plus,
-        ruler,
-        settingsFilled,
-        settings,
-        stethoscope,
-        stream,
-        syringe,
-        tablet,
-        userFilled,
-        userLinkFilled,
-        userLink,
-        user,
-        weight
-      ];
+    apple,
+    arrowLeft,
+    arrowRight,
+    bottle,
+    cake,
+    calendarFilled,
+    calendar,
+    check,
+    chevronBack,
+    chevronDown,
+    chevronLeft,
+    chevronRight,
+    chevronUp,
+    clockFilled,
+    clock,
+    cross,
+    cupFiiled,
+    cup,
+    deleteFilled,
+    delete,
+    detailsFilled,
+    details,
+    distance,
+    dna,
+    dropletAltFilled,
+    dropletAlt,
+    dropletFilled,
+    droplet,
+    edit,
+    emergencyAltFilled,
+    emergencyAlt,
+    emergency,
+    eyeOff,
+    eye,
+    filter,
+    google,
+    googleLogoColor,
+    heartFilled,
+    heart,
+    homeAltFilled,
+    homeAlt,
+    homeFilled,
+    home,
+    locationFilled,
+    locationOffFilled,
+    locationOff,
+    location,
+    logOut,
+    medicationFilled,
+    medication,
+    moonFilled,
+    moon,
+    peopleFilled,
+    people,
+    phoneFilled,
+    phone,
+    plus,
+    ruler,
+    settingsFilled,
+    settings,
+    stethoscope,
+    stream,
+    syringe,
+    tablet,
+    userFilled,
+    userLinkFilled,
+    userLink,
+    user,
+    weight,
+  ];
 }
 
 class $AssetsSvgIllustrationsGen {
@@ -458,23 +458,23 @@ class $AssetsSvgIllustrationsEmojisGen {
 
   /// List of all assets
   List<dynamic> get values => [
-        beamingFaceSmilingEyes,
-        blushingSmilingFace,
-        clappingHands,
-        confusedFace,
-        grinningFaceBigEyes,
-        grinningFaceSmilingEyes,
-        grinningFace,
-        grinningSquintingFace,
-        okHand,
-        peaceHand,
-        slightlySmilingFace,
-        smilingFaceHalo,
-        smilingFaceWithTear,
-        thumbsUp,
-        upsideDownSmilingFace,
-        winkingFace
-      ];
+    beamingFaceSmilingEyes,
+    blushingSmilingFace,
+    clappingHands,
+    confusedFace,
+    grinningFaceBigEyes,
+    grinningFaceSmilingEyes,
+    grinningFace,
+    grinningSquintingFace,
+    okHand,
+    peaceHand,
+    slightlySmilingFace,
+    smilingFaceHalo,
+    smilingFaceWithTear,
+    thumbsUp,
+    upsideDownSmilingFace,
+    winkingFace,
+  ];
 }
 
 class Assets {
@@ -486,11 +486,7 @@ class Assets {
 }
 
 class AssetGenImage {
-  const AssetGenImage(
-    this._assetName, {
-    this.size,
-    this.flavors = const {},
-  });
+  const AssetGenImage(this._assetName, {this.size, this.flavors = const {}});
 
   final String _assetName;
 
@@ -550,15 +546,8 @@ class AssetGenImage {
     );
   }
 
-  ImageProvider provider({
-    AssetBundle? bundle,
-    String? package,
-  }) {
-    return AssetImage(
-      _assetName,
-      bundle: bundle,
-      package: package,
-    );
+  ImageProvider provider({AssetBundle? bundle, String? package}) {
+    return AssetImage(_assetName, bundle: bundle, package: package);
   }
 
   String get path => _assetName;

--- a/lib/objectbox.g.dart
+++ b/lib/objectbox.g.dart
@@ -26,524 +26,621 @@ export 'package:objectbox/objectbox.dart'; // so that callers only have to impor
 
 final _entities = <obx_int.ModelEntity>[
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(2, 7166028067144916976),
-      name: 'UserProfile',
-      lastPropertyId: const obx_int.IdUid(22, 7473741569339705467),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 7096745133435402091),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 5360133605550174324),
-            name: 'uid',
-            type: 9,
-            flags: 34848,
-            indexId: const obx_int.IdUid(6, 8320414490647314865)),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 2642145193887279486),
-            name: 'name',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 4395116447830403324),
-            name: 'displayName',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 8429495187897421578),
-            name: 'age',
-            type: 6,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 269684340983521806),
-            name: 'email',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 705516932664929996),
-            name: 'photoUrl',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 1664576630604936704),
-            name: 'phone',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(9, 7192482139177737210),
-            name: 'painSeverity',
-            type: 6,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(10, 1724840226639888386),
-            name: 'crisisFrequency',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(11, 6629241393886714269),
-            name: 'height',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(12, 7408718016768229555),
-            name: 'weight',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(13, 8969005121810407638),
-            name: 'bmi',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(14, 7467163394291670971),
-            name: 'bloodGroup',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(15, 1424233479968241717),
-            name: 'allergies',
-            type: 30,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(16, 5346806588601411509),
-            name: 'medicalConditions',
-            type: 30,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(17, 3418391106783914792),
-            name: 'dbGender',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(18, 1583331589492315386),
-            name: 'dbGenotype',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(19, 2015269629626789463),
-            name: 'isDeleted',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(20, 8568252093008437148),
-            name: 'isSynced',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(21, 6958654057075105045),
-            name: 'updatedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(22, 7473741569339705467),
-            name: 'createdAt',
-            type: 10,
-            flags: 0)
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(2, 7166028067144916976),
+    name: 'UserProfile',
+    lastPropertyId: const obx_int.IdUid(22, 7473741569339705467),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 7096745133435402091),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 5360133605550174324),
+        name: 'uid',
+        type: 9,
+        flags: 34848,
+        indexId: const obx_int.IdUid(6, 8320414490647314865),
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 2642145193887279486),
+        name: 'name',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 4395116447830403324),
+        name: 'displayName',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 8429495187897421578),
+        name: 'age',
+        type: 6,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 269684340983521806),
+        name: 'email',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 705516932664929996),
+        name: 'photoUrl',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 1664576630604936704),
+        name: 'phone',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(9, 7192482139177737210),
+        name: 'painSeverity',
+        type: 6,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 1724840226639888386),
+        name: 'crisisFrequency',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(11, 6629241393886714269),
+        name: 'height',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(12, 7408718016768229555),
+        name: 'weight',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(13, 8969005121810407638),
+        name: 'bmi',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(14, 7467163394291670971),
+        name: 'bloodGroup',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(15, 1424233479968241717),
+        name: 'allergies',
+        type: 30,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(16, 5346806588601411509),
+        name: 'medicalConditions',
+        type: 30,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(17, 3418391106783914792),
+        name: 'dbGender',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(18, 1583331589492315386),
+        name: 'dbGenotype',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(19, 2015269629626789463),
+        name: 'isDeleted',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(20, 8568252093008437148),
+        name: 'isSynced',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(21, 6958654057075105045),
+        name: 'updatedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(22, 7473741569339705467),
+        name: 'createdAt',
+        type: 10,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(4, 9220182941712639121),
-      name: 'WaterLog',
-      lastPropertyId: const obx_int.IdUid(4, 8044481272773995284),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 2390008030440043296),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 3899823053853080757),
-            name: 'timestamp',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 7571913508040307035),
-            name: 'value',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 8044481272773995284),
-            name: 'dbUnit',
-            type: 9,
-            flags: 0)
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(4, 9220182941712639121),
+    name: 'WaterLog',
+    lastPropertyId: const obx_int.IdUid(4, 8044481272773995284),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 2390008030440043296),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 3899823053853080757),
+        name: 'timestamp',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 7571913508040307035),
+        name: 'value',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 8044481272773995284),
+        name: 'dbUnit',
+        type: 9,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(5, 8525861671860013939),
-      name: 'WaterPreferences',
-      lastPropertyId: const obx_int.IdUid(8, 2412091363281165),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 5659237027889275562),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 6782218037740632246),
-            name: 'defaultDailyGoal',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 2807300026539704189),
-            name: 'defaultLogValue',
-            type: 8,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 5185646952489030688),
-            name: 'dbUnit',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 8185185093777238402),
-            name: 'isDeleted',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 543910472144146717),
-            name: 'isSynced',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 7935083643204063984),
-            name: 'updatedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 2412091363281165),
-            name: 'createdAt',
-            type: 10,
-            flags: 0)
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(5, 8525861671860013939),
+    name: 'WaterPreferences',
+    lastPropertyId: const obx_int.IdUid(8, 2412091363281165),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 5659237027889275562),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 6782218037740632246),
+        name: 'defaultDailyGoal',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 2807300026539704189),
+        name: 'defaultLogValue',
+        type: 8,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 5185646952489030688),
+        name: 'dbUnit',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 8185185093777238402),
+        name: 'isDeleted',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 543910472144146717),
+        name: 'isSynced',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 7935083643204063984),
+        name: 'updatedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 2412091363281165),
+        name: 'createdAt',
+        type: 10,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(8, 3148493177410260898),
-      name: 'Medication',
-      lastPropertyId: const obx_int.IdUid(21, 1022375710724095450),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 8311454502694335069),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 9145557492682008945),
-            name: 'name',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 1789520699936360697),
-            name: 'description',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 683296172488219404),
-            name: 'durationDays',
-            type: 6,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 8225477852272397144),
-            name: 'isPermanent',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 3484228046199376424),
-            name: 'shouldRemind',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 2074261615147149631),
-            name: 'reminderMessage',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 2950443469283825435),
-            name: 'warningMessage',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(10, 6214859084849299397),
-            name: 'startDate',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(11, 8300745868109834209),
-            name: 'endDate',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(12, 4695932629066880040),
-            name: 'dbType',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(13, 8451063112463280957),
-            name: 'dbDose',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(14, 1814100054573638532),
-            name: 'dbFrequency',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(15, 4314761332996949634),
-            name: 'dbStreak',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(16, 303937560231408961),
-            name: 'isDeleted',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(17, 4891944372309835817),
-            name: 'isSynced',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(18, 3488073738162862170),
-            name: 'updatedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(20, 7010890984311908694),
-            name: 'createdAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(21, 1022375710724095450),
-            name: 'uid',
-            type: 9,
-            flags: 34848,
-            indexId: const obx_int.IdUid(10, 7451178347421563325))
-      ],
-      relations: <obx_int.ModelRelation>[
-        obx_int.ModelRelation(
-            id: const obx_int.IdUid(3, 7294710979211216290),
-            name: 'activityRecord',
-            targetId: const obx_int.IdUid(11, 6957825818410986359))
-      ],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(8, 3148493177410260898),
+    name: 'Medication',
+    lastPropertyId: const obx_int.IdUid(21, 1022375710724095450),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 8311454502694335069),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 9145557492682008945),
+        name: 'name',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 1789520699936360697),
+        name: 'description',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 683296172488219404),
+        name: 'durationDays',
+        type: 6,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 8225477852272397144),
+        name: 'isPermanent',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 3484228046199376424),
+        name: 'shouldRemind',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 2074261615147149631),
+        name: 'reminderMessage',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 2950443469283825435),
+        name: 'warningMessage',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 6214859084849299397),
+        name: 'startDate',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(11, 8300745868109834209),
+        name: 'endDate',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(12, 4695932629066880040),
+        name: 'dbType',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(13, 8451063112463280957),
+        name: 'dbDose',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(14, 1814100054573638532),
+        name: 'dbFrequency',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(15, 4314761332996949634),
+        name: 'dbStreak',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(16, 303937560231408961),
+        name: 'isDeleted',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(17, 4891944372309835817),
+        name: 'isSynced',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(18, 3488073738162862170),
+        name: 'updatedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(20, 7010890984311908694),
+        name: 'createdAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(21, 1022375710724095450),
+        name: 'uid',
+        type: 9,
+        flags: 34848,
+        indexId: const obx_int.IdUid(10, 7451178347421563325),
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[
+      obx_int.ModelRelation(
+        id: const obx_int.IdUid(3, 7294710979211216290),
+        name: 'activityRecord',
+        targetId: const obx_int.IdUid(11, 6957825818410986359),
+      ),
+    ],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(10, 3540123216790538936),
-      name: 'AppUser',
-      lastPropertyId: const obx_int.IdUid(12, 7806579562095076535),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 8512746970314953838),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 388611142959808954),
-            name: 'uid',
-            type: 9,
-            flags: 34848,
-            indexId: const obx_int.IdUid(7, 9122980928938211868)),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 461186542082764755),
-            name: 'email',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 3313684145660166762),
-            name: 'photoUrl',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 5645595606836568249),
-            name: 'isAnonymous',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 6171172290814305356),
-            name: 'isEmailVerified',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 7902560646269532341),
-            name: 'isPhoneVerified',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 1030238237745064050),
-            name: 'profileId',
-            type: 11,
-            flags: 520,
-            indexId: const obx_int.IdUid(8, 5330077494103882266),
-            relationTarget: 'UserProfile'),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(9, 2196504888248073330),
-            name: 'dbPreferences',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(10, 547505417067333554),
-            name: 'isDeleted',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(11, 2448644833171259802),
-            name: 'isSynced',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(12, 7806579562095076535),
-            name: 'updatedAt',
-            type: 10,
-            flags: 0)
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(10, 3540123216790538936),
+    name: 'AppUser',
+    lastPropertyId: const obx_int.IdUid(12, 7806579562095076535),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 8512746970314953838),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 388611142959808954),
+        name: 'uid',
+        type: 9,
+        flags: 34848,
+        indexId: const obx_int.IdUid(7, 9122980928938211868),
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 461186542082764755),
+        name: 'email',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 3313684145660166762),
+        name: 'photoUrl',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 5645595606836568249),
+        name: 'isAnonymous',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 6171172290814305356),
+        name: 'isEmailVerified',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 7902560646269532341),
+        name: 'isPhoneVerified',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 1030238237745064050),
+        name: 'profileId',
+        type: 11,
+        flags: 520,
+        indexId: const obx_int.IdUid(8, 5330077494103882266),
+        relationTarget: 'UserProfile',
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(9, 2196504888248073330),
+        name: 'dbPreferences',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 547505417067333554),
+        name: 'isDeleted',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(11, 2448644833171259802),
+        name: 'isSynced',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(12, 7806579562095076535),
+        name: 'updatedAt',
+        type: 10,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(11, 6957825818410986359),
-      name: 'MedActivityRecord',
-      lastPropertyId: const obx_int.IdUid(10, 1881334460722875207),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 1633406102808477893),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 5512567593919371215),
-            name: 'dbType',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 7170542944779333196),
-            name: 'dbStatus',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 4950765526072304608),
-            name: 'dbActivityDetails',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 1340821114564136010),
-            name: 'completedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 5179221082217146965),
-            name: 'date',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 997915738891991722),
-            name: 'note',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(9, 7177102249851450606),
-            name: 'skipReason',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(10, 1881334460722875207),
-            name: 'parentId',
-            type: 9,
-            flags: 0)
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[]),
+    id: const obx_int.IdUid(11, 6957825818410986359),
+    name: 'MedActivityRecord',
+    lastPropertyId: const obx_int.IdUid(10, 1881334460722875207),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 1633406102808477893),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 5512567593919371215),
+        name: 'dbType',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 7170542944779333196),
+        name: 'dbStatus',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 4950765526072304608),
+        name: 'dbActivityDetails',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 1340821114564136010),
+        name: 'completedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 5179221082217146965),
+        name: 'date',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 997915738891991722),
+        name: 'note',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(9, 7177102249851450606),
+        name: 'skipReason',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 1881334460722875207),
+        name: 'parentId',
+        type: 9,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
   obx_int.ModelEntity(
-      id: const obx_int.IdUid(14, 4275058572695879075),
-      name: 'ScheduledDose',
-      lastPropertyId: const obx_int.IdUid(15, 4105671264254087409),
-      flags: 0,
-      properties: <obx_int.ModelProperty>[
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(1, 8176731916170743628),
-            name: 'id',
-            type: 6,
-            flags: 1),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(2, 2851297118854552514),
-            name: 'completedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(3, 8241597806845827288),
-            name: 'date',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(4, 5772704008257699971),
-            name: 'note',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(5, 4806166249594307760),
-            name: 'skipReason',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(6, 5648399380272787407),
-            name: 'parentId',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(7, 1419836986027387224),
-            name: 'isDeleted',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(8, 5230393866022405568),
-            name: 'isSynced',
-            type: 1,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(9, 2932274522209157465),
-            name: 'updatedAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(10, 6287725381687062897),
-            name: 'createdAt',
-            type: 10,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(11, 1224533935760049178),
-            name: 'dbActivityType',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(12, 5501191734441891561),
-            name: 'dbStatus',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(13, 8722358136278641904),
-            name: 'dbActivityDetails',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(14, 5604762930702115242),
-            name: 'dbDose',
-            type: 9,
-            flags: 0),
-        obx_int.ModelProperty(
-            id: const obx_int.IdUid(15, 4105671264254087409),
-            name: 'uid',
-            type: 9,
-            flags: 34848,
-            indexId: const obx_int.IdUid(11, 6292842501519135102))
-      ],
-      relations: <obx_int.ModelRelation>[],
-      backlinks: <obx_int.ModelBacklink>[])
+    id: const obx_int.IdUid(14, 4275058572695879075),
+    name: 'ScheduledDose',
+    lastPropertyId: const obx_int.IdUid(15, 4105671264254087409),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 8176731916170743628),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 2851297118854552514),
+        name: 'completedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 8241597806845827288),
+        name: 'date',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 5772704008257699971),
+        name: 'note',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 4806166249594307760),
+        name: 'skipReason',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 5648399380272787407),
+        name: 'parentId',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 1419836986027387224),
+        name: 'isDeleted',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 5230393866022405568),
+        name: 'isSynced',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(9, 2932274522209157465),
+        name: 'updatedAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 6287725381687062897),
+        name: 'createdAt',
+        type: 10,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(11, 1224533935760049178),
+        name: 'dbActivityType',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(12, 5501191734441891561),
+        name: 'dbStatus',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(13, 8722358136278641904),
+        name: 'dbActivityDetails',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(14, 5604762930702115242),
+        name: 'dbDose',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(15, 4105671264254087409),
+        name: 'uid',
+        type: 9,
+        flags: 34848,
+        indexId: const obx_int.IdUid(11, 6292842501519135102),
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
 ];
 
 /// Shortcut for [obx.Store.new] that passes [getObjectBoxModel] and for Flutter
@@ -557,751 +654,979 @@ final _entities = <obx_int.ModelEntity>[
 /// For Flutter apps, also calls `loadObjectBoxLibraryAndroidCompat()` from
 /// the ObjectBox Flutter library to fix loading the native ObjectBox library
 /// on Android 6 and older.
-Future<obx.Store> openStore(
-    {String? directory,
-    int? maxDBSizeInKB,
-    int? maxDataSizeInKB,
-    int? fileMode,
-    int? maxReaders,
-    bool queriesCaseSensitiveDefault = true,
-    String? macosApplicationGroup}) async {
+Future<obx.Store> openStore({
+  String? directory,
+  int? maxDBSizeInKB,
+  int? maxDataSizeInKB,
+  int? fileMode,
+  int? maxReaders,
+  bool queriesCaseSensitiveDefault = true,
+  String? macosApplicationGroup,
+}) async {
   await loadObjectBoxLibraryAndroidCompat();
-  return obx.Store(getObjectBoxModel(),
-      directory: directory ?? (await defaultStoreDirectory()).path,
-      maxDBSizeInKB: maxDBSizeInKB,
-      maxDataSizeInKB: maxDataSizeInKB,
-      fileMode: fileMode,
-      maxReaders: maxReaders,
-      queriesCaseSensitiveDefault: queriesCaseSensitiveDefault,
-      macosApplicationGroup: macosApplicationGroup);
+  return obx.Store(
+    getObjectBoxModel(),
+    directory: directory ?? (await defaultStoreDirectory()).path,
+    maxDBSizeInKB: maxDBSizeInKB,
+    maxDataSizeInKB: maxDataSizeInKB,
+    fileMode: fileMode,
+    maxReaders: maxReaders,
+    queriesCaseSensitiveDefault: queriesCaseSensitiveDefault,
+    macosApplicationGroup: macosApplicationGroup,
+  );
 }
 
 /// Returns the ObjectBox model definition for this project for use with
 /// [obx.Store.new].
 obx_int.ModelDefinition getObjectBoxModel() {
   final model = obx_int.ModelInfo(
-      entities: _entities,
-      lastEntityId: const obx_int.IdUid(14, 4275058572695879075),
-      lastIndexId: const obx_int.IdUid(11, 6292842501519135102),
-      lastRelationId: const obx_int.IdUid(3, 7294710979211216290),
-      lastSequenceId: const obx_int.IdUid(0, 0),
-      retiredEntityUids: const [
-        207629943991403341,
-        3501377542454085602,
-        867207695587786430,
-        9210468346883610997,
-        1910794932095842795,
-        1339963485057644468,
-        8773604070706490068
-      ],
-      retiredIndexUids: const [
-        8176574082609213585,
-        7305761162520707228,
-        7057256903890307851
-      ],
-      retiredPropertyUids: const [
-        1282289976025498362,
-        1939078546095740939,
-        4071794349192739105,
-        2619329977048293077,
-        6118583753238647522,
-        6382803102056889443,
-        2487054705505549957,
-        4301197917219853271,
-        7597971790492722902,
-        2278733653192405247,
-        6280962215202403385,
-        4588681087413634416,
-        5800574081436917065,
-        5381275457373125277,
-        7362056251971348217,
-        3990587320212176692,
-        1251136044700750690,
-        7394159863890390396,
-        6641010694088898159,
-        9046109760705459622,
-        7851169316088979097,
-        7776106648647357425,
-        6382851924054177629,
-        1938034445264548325,
-        6756802899985026265,
-        4137700724415044066,
-        7538616858440401534,
-        4322896623179610370,
-        589524113363230822,
-        5351588759555286712,
-        8332419882270310101,
-        6793769419637763149,
-        417247235985229651,
-        5185424966544459360,
-        927931047185036496,
-        8273309073968860340,
-        2555433748586013967,
-        7223991870356115469,
-        8399786612049634084,
-        391968824388424808,
-        5890801838528296916,
-        5647413884932250945,
-        1983841816402486938,
-        6178216030160449883,
-        3097083884408393914,
-        3791689441908872094,
-        7290586427487009004,
-        2133907886604377565,
-        3614142052002170477,
-        9141182723067187527,
-        8424249390367698456,
-        1605055043486623585,
-        4170973310821413935,
-        5544854253602746622,
-        234129658498633719,
-        8681007331577343761,
-        905347763044908435,
-        962829797831035542,
-        4053460168341695725,
-        348936209633946731,
-        6723772750807864963,
-        4053016393902170366,
-        6171521520006031931,
-        1072389071086573832,
-        8426648264857871979,
-        7506353066611055334,
-        8812915512390146915,
-        6791044842289382902,
-        4487206203660110259,
-        7593395598541999766,
-        5028455532129656100,
-        5741700252410311329,
-        6744692704282181672,
-        271172681437230255
-      ],
-      retiredRelationUids: const [3092819797569954146, 2539627836723066308],
-      modelVersion: 5,
-      modelVersionParserMinimum: 5,
-      version: 1);
+    entities: _entities,
+    lastEntityId: const obx_int.IdUid(14, 4275058572695879075),
+    lastIndexId: const obx_int.IdUid(11, 6292842501519135102),
+    lastRelationId: const obx_int.IdUid(3, 7294710979211216290),
+    lastSequenceId: const obx_int.IdUid(0, 0),
+    retiredEntityUids: const [
+      207629943991403341,
+      3501377542454085602,
+      867207695587786430,
+      9210468346883610997,
+      1910794932095842795,
+      1339963485057644468,
+      8773604070706490068,
+    ],
+    retiredIndexUids: const [
+      8176574082609213585,
+      7305761162520707228,
+      7057256903890307851,
+    ],
+    retiredPropertyUids: const [
+      1282289976025498362,
+      1939078546095740939,
+      4071794349192739105,
+      2619329977048293077,
+      6118583753238647522,
+      6382803102056889443,
+      2487054705505549957,
+      4301197917219853271,
+      7597971790492722902,
+      2278733653192405247,
+      6280962215202403385,
+      4588681087413634416,
+      5800574081436917065,
+      5381275457373125277,
+      7362056251971348217,
+      3990587320212176692,
+      1251136044700750690,
+      7394159863890390396,
+      6641010694088898159,
+      9046109760705459622,
+      7851169316088979097,
+      7776106648647357425,
+      6382851924054177629,
+      1938034445264548325,
+      6756802899985026265,
+      4137700724415044066,
+      7538616858440401534,
+      4322896623179610370,
+      589524113363230822,
+      5351588759555286712,
+      8332419882270310101,
+      6793769419637763149,
+      417247235985229651,
+      5185424966544459360,
+      927931047185036496,
+      8273309073968860340,
+      2555433748586013967,
+      7223991870356115469,
+      8399786612049634084,
+      391968824388424808,
+      5890801838528296916,
+      5647413884932250945,
+      1983841816402486938,
+      6178216030160449883,
+      3097083884408393914,
+      3791689441908872094,
+      7290586427487009004,
+      2133907886604377565,
+      3614142052002170477,
+      9141182723067187527,
+      8424249390367698456,
+      1605055043486623585,
+      4170973310821413935,
+      5544854253602746622,
+      234129658498633719,
+      8681007331577343761,
+      905347763044908435,
+      962829797831035542,
+      4053460168341695725,
+      348936209633946731,
+      6723772750807864963,
+      4053016393902170366,
+      6171521520006031931,
+      1072389071086573832,
+      8426648264857871979,
+      7506353066611055334,
+      8812915512390146915,
+      6791044842289382902,
+      4487206203660110259,
+      7593395598541999766,
+      5028455532129656100,
+      5741700252410311329,
+      6744692704282181672,
+      271172681437230255,
+    ],
+    retiredRelationUids: const [3092819797569954146, 2539627836723066308],
+    modelVersion: 5,
+    modelVersionParserMinimum: 5,
+    version: 1,
+  );
 
   final bindings = <Type, obx_int.EntityDefinition>{
     UserProfile: obx_int.EntityDefinition<UserProfile>(
-        model: _entities[0],
-        toOneRelations: (UserProfile object) => [],
-        toManyRelations: (UserProfile object) => {},
-        getId: (UserProfile object) => object.id,
-        setId: (UserProfile object, int id) {
-          object.id = id;
-        },
-        objectToFB: (UserProfile object, fb.Builder fbb) {
-          final uidOffset =
-              object.uid == null ? null : fbb.writeString(object.uid!);
-          final nameOffset =
-              object.name == null ? null : fbb.writeString(object.name!);
-          final displayNameOffset = object.displayName == null
-              ? null
-              : fbb.writeString(object.displayName!);
-          final emailOffset =
-              object.email == null ? null : fbb.writeString(object.email!);
-          final photoUrlOffset = object.photoUrl == null
-              ? null
-              : fbb.writeString(object.photoUrl!);
-          final phoneOffset =
-              object.phone == null ? null : fbb.writeString(object.phone!);
-          final crisisFrequencyOffset = object.crisisFrequency == null
-              ? null
-              : fbb.writeString(object.crisisFrequency!);
-          final bloodGroupOffset = object.bloodGroup == null
-              ? null
-              : fbb.writeString(object.bloodGroup!);
-          final allergiesOffset = object.allergies == null
-              ? null
-              : fbb.writeList(object.allergies!
-                  .map(fbb.writeString)
-                  .toList(growable: false));
-          final medicalConditionsOffset = object.medicalConditions == null
-              ? null
-              : fbb.writeList(object.medicalConditions!
-                  .map(fbb.writeString)
-                  .toList(growable: false));
-          final dbGenderOffset = object.dbGender == null
-              ? null
-              : fbb.writeString(object.dbGender!);
-          final dbGenotypeOffset = object.dbGenotype == null
-              ? null
-              : fbb.writeString(object.dbGenotype!);
-          fbb.startTable(23);
-          fbb.addInt64(0, object.id);
-          fbb.addOffset(1, uidOffset);
-          fbb.addOffset(2, nameOffset);
-          fbb.addOffset(3, displayNameOffset);
-          fbb.addInt64(4, object.age);
-          fbb.addOffset(5, emailOffset);
-          fbb.addOffset(6, photoUrlOffset);
-          fbb.addOffset(7, phoneOffset);
-          fbb.addInt64(8, object.painSeverity);
-          fbb.addOffset(9, crisisFrequencyOffset);
-          fbb.addFloat64(10, object.height);
-          fbb.addFloat64(11, object.weight);
-          fbb.addFloat64(12, object.bmi);
-          fbb.addOffset(13, bloodGroupOffset);
-          fbb.addOffset(14, allergiesOffset);
-          fbb.addOffset(15, medicalConditionsOffset);
-          fbb.addOffset(16, dbGenderOffset);
-          fbb.addOffset(17, dbGenotypeOffset);
-          fbb.addBool(18, object.isDeleted);
-          fbb.addBool(19, object.isSynced);
-          fbb.addInt64(20, object.updatedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(21, object.createdAt?.millisecondsSinceEpoch);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final updatedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 44);
-          final createdAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 46);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final uidParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 6);
-          final nameParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 8);
-          final ageParam =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 12);
-          final displayNameParam =
-              const fb.StringReader(asciiOptimization: true)
-                  .vTableGetNullable(buffer, rootOffset, 10);
-          final emailParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 14);
-          final photoUrlParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 16);
-          final phoneParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 18);
-          final crisisFrequencyParam =
-              const fb.StringReader(asciiOptimization: true)
-                  .vTableGetNullable(buffer, rootOffset, 22);
-          final painSeverityParam =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 20);
-          final heightParam = const fb.Float64Reader()
-              .vTableGetNullable(buffer, rootOffset, 24);
-          final weightParam = const fb.Float64Reader()
-              .vTableGetNullable(buffer, rootOffset, 26);
-          final bmiParam = const fb.Float64Reader()
-              .vTableGetNullable(buffer, rootOffset, 28);
-          final bloodGroupParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 30);
-          final allergiesParam = const fb.ListReader<String>(
-                  fb.StringReader(asciiOptimization: true),
-                  lazy: false)
-              .vTableGetNullable(buffer, rootOffset, 32);
-          final medicalConditionsParam = const fb.ListReader<String>(
-                  fb.StringReader(asciiOptimization: true),
-                  lazy: false)
-              .vTableGetNullable(buffer, rootOffset, 34);
-          final isDeletedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 40, false);
-          final isSyncedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 42, false);
-          final updatedAtParam = updatedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
-          final createdAtParam = createdAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
-          final object = UserProfile(
-              id: idParam,
-              uid: uidParam,
-              name: nameParam,
-              age: ageParam,
-              displayName: displayNameParam,
-              email: emailParam,
-              photoUrl: photoUrlParam,
-              phone: phoneParam,
-              crisisFrequency: crisisFrequencyParam,
-              painSeverity: painSeverityParam,
-              height: heightParam,
-              weight: weightParam,
-              bmi: bmiParam,
-              bloodGroup: bloodGroupParam,
-              allergies: allergiesParam,
-              medicalConditions: medicalConditionsParam,
-              isDeleted: isDeletedParam,
-              isSynced: isSyncedParam,
-              updatedAt: updatedAtParam,
-              createdAt: createdAtParam)
-            ..dbGender = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 36)
-            ..dbGenotype = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 38);
+      model: _entities[0],
+      toOneRelations: (UserProfile object) => [],
+      toManyRelations: (UserProfile object) => {},
+      getId: (UserProfile object) => object.id,
+      setId: (UserProfile object, int id) {
+        object.id = id;
+      },
+      objectToFB: (UserProfile object, fb.Builder fbb) {
+        final uidOffset = object.uid == null
+            ? null
+            : fbb.writeString(object.uid!);
+        final nameOffset = object.name == null
+            ? null
+            : fbb.writeString(object.name!);
+        final displayNameOffset = object.displayName == null
+            ? null
+            : fbb.writeString(object.displayName!);
+        final emailOffset = object.email == null
+            ? null
+            : fbb.writeString(object.email!);
+        final photoUrlOffset = object.photoUrl == null
+            ? null
+            : fbb.writeString(object.photoUrl!);
+        final phoneOffset = object.phone == null
+            ? null
+            : fbb.writeString(object.phone!);
+        final crisisFrequencyOffset = object.crisisFrequency == null
+            ? null
+            : fbb.writeString(object.crisisFrequency!);
+        final bloodGroupOffset = object.bloodGroup == null
+            ? null
+            : fbb.writeString(object.bloodGroup!);
+        final allergiesOffset = object.allergies == null
+            ? null
+            : fbb.writeList(
+                object.allergies!.map(fbb.writeString).toList(growable: false),
+              );
+        final medicalConditionsOffset = object.medicalConditions == null
+            ? null
+            : fbb.writeList(
+                object.medicalConditions!
+                    .map(fbb.writeString)
+                    .toList(growable: false),
+              );
+        final dbGenderOffset = object.dbGender == null
+            ? null
+            : fbb.writeString(object.dbGender!);
+        final dbGenotypeOffset = object.dbGenotype == null
+            ? null
+            : fbb.writeString(object.dbGenotype!);
+        fbb.startTable(23);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, uidOffset);
+        fbb.addOffset(2, nameOffset);
+        fbb.addOffset(3, displayNameOffset);
+        fbb.addInt64(4, object.age);
+        fbb.addOffset(5, emailOffset);
+        fbb.addOffset(6, photoUrlOffset);
+        fbb.addOffset(7, phoneOffset);
+        fbb.addInt64(8, object.painSeverity);
+        fbb.addOffset(9, crisisFrequencyOffset);
+        fbb.addFloat64(10, object.height);
+        fbb.addFloat64(11, object.weight);
+        fbb.addFloat64(12, object.bmi);
+        fbb.addOffset(13, bloodGroupOffset);
+        fbb.addOffset(14, allergiesOffset);
+        fbb.addOffset(15, medicalConditionsOffset);
+        fbb.addOffset(16, dbGenderOffset);
+        fbb.addOffset(17, dbGenotypeOffset);
+        fbb.addBool(18, object.isDeleted);
+        fbb.addBool(19, object.isSynced);
+        fbb.addInt64(20, object.updatedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(21, object.createdAt?.millisecondsSinceEpoch);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final updatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          44,
+        );
+        final createdAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          46,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final uidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 6);
+        final nameParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 8);
+        final ageParam = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          12,
+        );
+        final displayNameParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 10);
+        final emailParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 14);
+        final photoUrlParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 16);
+        final phoneParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 18);
+        final crisisFrequencyParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 22);
+        final painSeverityParam = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          20,
+        );
+        final heightParam = const fb.Float64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          24,
+        );
+        final weightParam = const fb.Float64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          26,
+        );
+        final bmiParam = const fb.Float64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          28,
+        );
+        final bloodGroupParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 30);
+        final allergiesParam = const fb.ListReader<String>(
+          fb.StringReader(asciiOptimization: true),
+          lazy: false,
+        ).vTableGetNullable(buffer, rootOffset, 32);
+        final medicalConditionsParam = const fb.ListReader<String>(
+          fb.StringReader(asciiOptimization: true),
+          lazy: false,
+        ).vTableGetNullable(buffer, rootOffset, 34);
+        final isDeletedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          40,
+          false,
+        );
+        final isSyncedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          42,
+          false,
+        );
+        final updatedAtParam = updatedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
+        final createdAtParam = createdAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
+        final object =
+            UserProfile(
+                id: idParam,
+                uid: uidParam,
+                name: nameParam,
+                age: ageParam,
+                displayName: displayNameParam,
+                email: emailParam,
+                photoUrl: photoUrlParam,
+                phone: phoneParam,
+                crisisFrequency: crisisFrequencyParam,
+                painSeverity: painSeverityParam,
+                height: heightParam,
+                weight: weightParam,
+                bmi: bmiParam,
+                bloodGroup: bloodGroupParam,
+                allergies: allergiesParam,
+                medicalConditions: medicalConditionsParam,
+                isDeleted: isDeletedParam,
+                isSynced: isSyncedParam,
+                updatedAt: updatedAtParam,
+                createdAt: createdAtParam,
+              )
+              ..dbGender = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 36)
+              ..dbGenotype = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 38);
 
-          return object;
-        }),
+        return object;
+      },
+    ),
     WaterLog: obx_int.EntityDefinition<WaterLog>(
-        model: _entities[1],
-        toOneRelations: (WaterLog object) => [],
-        toManyRelations: (WaterLog object) => {},
-        getId: (WaterLog object) => object.id,
-        setId: (WaterLog object, int id) {
-          object.id = id;
-        },
-        objectToFB: (WaterLog object, fb.Builder fbb) {
-          final dbUnitOffset = fbb.writeString(object.dbUnit);
-          fbb.startTable(5);
-          fbb.addInt64(0, object.id);
-          fbb.addInt64(1, object.timestamp.millisecondsSinceEpoch);
-          fbb.addFloat64(2, object.value);
-          fbb.addOffset(3, dbUnitOffset);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final timestampParam = DateTime.fromMillisecondsSinceEpoch(
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0));
-          final valueParam =
-              const fb.Float64Reader().vTableGet(buffer, rootOffset, 8, 0);
-          final object = WaterLog(
-              id: idParam, timestamp: timestampParam, value: valueParam)
-            ..dbUnit = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 10, '');
+      model: _entities[1],
+      toOneRelations: (WaterLog object) => [],
+      toManyRelations: (WaterLog object) => {},
+      getId: (WaterLog object) => object.id,
+      setId: (WaterLog object, int id) {
+        object.id = id;
+      },
+      objectToFB: (WaterLog object, fb.Builder fbb) {
+        final dbUnitOffset = fbb.writeString(object.dbUnit);
+        fbb.startTable(5);
+        fbb.addInt64(0, object.id);
+        fbb.addInt64(1, object.timestamp.millisecondsSinceEpoch);
+        fbb.addFloat64(2, object.value);
+        fbb.addOffset(3, dbUnitOffset);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final timestampParam = DateTime.fromMillisecondsSinceEpoch(
+          const fb.Int64Reader().vTableGet(buffer, rootOffset, 6, 0),
+        );
+        final valueParam = const fb.Float64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          8,
+          0,
+        );
+        final object =
+            WaterLog(id: idParam, timestamp: timestampParam, value: valueParam)
+              ..dbUnit = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 10, '');
 
-          return object;
-        }),
+        return object;
+      },
+    ),
     WaterPreferences: obx_int.EntityDefinition<WaterPreferences>(
-        model: _entities[2],
-        toOneRelations: (WaterPreferences object) => [],
-        toManyRelations: (WaterPreferences object) => {},
-        getId: (WaterPreferences object) => object.id,
-        setId: (WaterPreferences object, int id) {
-          object.id = id;
-        },
-        objectToFB: (WaterPreferences object, fb.Builder fbb) {
-          final dbUnitOffset =
-              object.dbUnit == null ? null : fbb.writeString(object.dbUnit!);
-          fbb.startTable(9);
-          fbb.addInt64(0, object.id);
-          fbb.addFloat64(1, object.defaultDailyGoal);
-          fbb.addFloat64(2, object.defaultLogValue);
-          fbb.addOffset(3, dbUnitOffset);
-          fbb.addBool(4, object.isDeleted);
-          fbb.addBool(5, object.isSynced);
-          fbb.addInt64(6, object.updatedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(7, object.createdAt?.millisecondsSinceEpoch);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final updatedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 16);
-          final createdAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 18);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final defaultDailyGoalParam =
-              const fb.Float64Reader().vTableGetNullable(buffer, rootOffset, 6);
-          final defaultLogValueParam =
-              const fb.Float64Reader().vTableGetNullable(buffer, rootOffset, 8);
-          final isDeletedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 12, false);
-          final isSyncedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 14, false);
-          final updatedAtParam = updatedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
-          final createdAtParam = createdAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
-          final object = WaterPreferences(
-              id: idParam,
-              defaultDailyGoal: defaultDailyGoalParam,
-              defaultLogValue: defaultLogValueParam,
-              isDeleted: isDeletedParam,
-              isSynced: isSyncedParam,
-              updatedAt: updatedAtParam,
-              createdAt: createdAtParam)
-            ..dbUnit = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 10);
+      model: _entities[2],
+      toOneRelations: (WaterPreferences object) => [],
+      toManyRelations: (WaterPreferences object) => {},
+      getId: (WaterPreferences object) => object.id,
+      setId: (WaterPreferences object, int id) {
+        object.id = id;
+      },
+      objectToFB: (WaterPreferences object, fb.Builder fbb) {
+        final dbUnitOffset = object.dbUnit == null
+            ? null
+            : fbb.writeString(object.dbUnit!);
+        fbb.startTable(9);
+        fbb.addInt64(0, object.id);
+        fbb.addFloat64(1, object.defaultDailyGoal);
+        fbb.addFloat64(2, object.defaultLogValue);
+        fbb.addOffset(3, dbUnitOffset);
+        fbb.addBool(4, object.isDeleted);
+        fbb.addBool(5, object.isSynced);
+        fbb.addInt64(6, object.updatedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(7, object.createdAt?.millisecondsSinceEpoch);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final updatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          16,
+        );
+        final createdAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          18,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final defaultDailyGoalParam = const fb.Float64Reader()
+            .vTableGetNullable(buffer, rootOffset, 6);
+        final defaultLogValueParam = const fb.Float64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          8,
+        );
+        final isDeletedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          12,
+          false,
+        );
+        final isSyncedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          14,
+          false,
+        );
+        final updatedAtParam = updatedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
+        final createdAtParam = createdAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
+        final object =
+            WaterPreferences(
+                id: idParam,
+                defaultDailyGoal: defaultDailyGoalParam,
+                defaultLogValue: defaultLogValueParam,
+                isDeleted: isDeletedParam,
+                isSynced: isSyncedParam,
+                updatedAt: updatedAtParam,
+                createdAt: createdAtParam,
+              )
+              ..dbUnit = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 10);
 
-          return object;
-        }),
+        return object;
+      },
+    ),
     Medication: obx_int.EntityDefinition<Medication>(
-        model: _entities[3],
-        toOneRelations: (Medication object) => [],
-        toManyRelations: (Medication object) => {
-              obx_int.RelInfo<Medication>.toMany(3, object.id):
-                  object.activityRecord
-            },
-        getId: (Medication object) => object.id,
-        setId: (Medication object, int id) {
-          object.id = id;
-        },
-        objectToFB: (Medication object, fb.Builder fbb) {
-          final nameOffset = fbb.writeString(object.name);
-          final descriptionOffset = object.description == null
-              ? null
-              : fbb.writeString(object.description!);
-          final reminderMessageOffset = object.reminderMessage == null
-              ? null
-              : fbb.writeString(object.reminderMessage!);
-          final warningMessageOffset = object.warningMessage == null
-              ? null
-              : fbb.writeString(object.warningMessage!);
-          final dbTypeOffset =
-              object.dbType == null ? null : fbb.writeString(object.dbType!);
-          final dbDoseOffset =
-              object.dbDose == null ? null : fbb.writeString(object.dbDose!);
-          final dbFrequencyOffset = object.dbFrequency == null
-              ? null
-              : fbb.writeString(object.dbFrequency!);
-          final dbStreakOffset = object.dbStreak == null
-              ? null
-              : fbb.writeString(object.dbStreak!);
-          final uidOffset = fbb.writeString(object.uid);
-          fbb.startTable(22);
-          fbb.addInt64(0, object.id);
-          fbb.addOffset(1, nameOffset);
-          fbb.addOffset(2, descriptionOffset);
-          fbb.addInt64(3, object.durationDays);
-          fbb.addBool(4, object.isPermanent);
-          fbb.addBool(5, object.shouldRemind);
-          fbb.addOffset(6, reminderMessageOffset);
-          fbb.addOffset(7, warningMessageOffset);
-          fbb.addInt64(9, object.startDate?.millisecondsSinceEpoch);
-          fbb.addInt64(10, object.endDate?.millisecondsSinceEpoch);
-          fbb.addOffset(11, dbTypeOffset);
-          fbb.addOffset(12, dbDoseOffset);
-          fbb.addOffset(13, dbFrequencyOffset);
-          fbb.addOffset(14, dbStreakOffset);
-          fbb.addBool(15, object.isDeleted);
-          fbb.addBool(16, object.isSynced);
-          fbb.addInt64(17, object.updatedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(19, object.createdAt?.millisecondsSinceEpoch);
-          fbb.addOffset(20, uidOffset);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final startDateValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 22);
-          final endDateValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 24);
-          final updatedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 38);
-          final createdAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 42);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final nameParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 6, '');
-          final uidParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 44, '');
-          final descriptionParam =
-              const fb.StringReader(asciiOptimization: true)
-                  .vTableGetNullable(buffer, rootOffset, 8);
-          final durationDaysParam =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 10);
-          final isPermanentParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 12, false);
-          final startDateParam = startDateValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(startDateValue);
-          final endDateParam = endDateValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(endDateValue);
-          final shouldRemindParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 14, false);
-          final reminderMessageParam =
-              const fb.StringReader(asciiOptimization: true)
-                  .vTableGetNullable(buffer, rootOffset, 16);
-          final warningMessageParam =
-              const fb.StringReader(asciiOptimization: true)
-                  .vTableGetNullable(buffer, rootOffset, 18);
-          final isDeletedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 34, false);
-          final isSyncedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 36, false);
-          final updatedAtParam = updatedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
-          final createdAtParam = createdAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
-          final object = Medication(
-              id: idParam,
-              name: nameParam,
-              uid: uidParam,
-              description: descriptionParam,
-              durationDays: durationDaysParam,
-              isPermanent: isPermanentParam,
-              startDate: startDateParam,
-              endDate: endDateParam,
-              shouldRemind: shouldRemindParam,
-              reminderMessage: reminderMessageParam,
-              warningMessage: warningMessageParam,
-              isDeleted: isDeletedParam,
-              isSynced: isSyncedParam,
-              updatedAt: updatedAtParam,
-              createdAt: createdAtParam)
-            ..dbType = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 26)
-            ..dbDose = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 28)
-            ..dbFrequency = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 30)
-            ..dbStreak = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 32);
-          obx_int.InternalToManyAccess.setRelInfo<Medication>(
-              object.activityRecord,
-              store,
-              obx_int.RelInfo<Medication>.toMany(3, object.id));
-          return object;
-        }),
+      model: _entities[3],
+      toOneRelations: (Medication object) => [],
+      toManyRelations: (Medication object) => {
+        obx_int.RelInfo<Medication>.toMany(3, object.id): object.activityRecord,
+      },
+      getId: (Medication object) => object.id,
+      setId: (Medication object, int id) {
+        object.id = id;
+      },
+      objectToFB: (Medication object, fb.Builder fbb) {
+        final nameOffset = fbb.writeString(object.name);
+        final descriptionOffset = object.description == null
+            ? null
+            : fbb.writeString(object.description!);
+        final reminderMessageOffset = object.reminderMessage == null
+            ? null
+            : fbb.writeString(object.reminderMessage!);
+        final warningMessageOffset = object.warningMessage == null
+            ? null
+            : fbb.writeString(object.warningMessage!);
+        final dbTypeOffset = object.dbType == null
+            ? null
+            : fbb.writeString(object.dbType!);
+        final dbDoseOffset = object.dbDose == null
+            ? null
+            : fbb.writeString(object.dbDose!);
+        final dbFrequencyOffset = object.dbFrequency == null
+            ? null
+            : fbb.writeString(object.dbFrequency!);
+        final dbStreakOffset = object.dbStreak == null
+            ? null
+            : fbb.writeString(object.dbStreak!);
+        final uidOffset = fbb.writeString(object.uid);
+        fbb.startTable(22);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, nameOffset);
+        fbb.addOffset(2, descriptionOffset);
+        fbb.addInt64(3, object.durationDays);
+        fbb.addBool(4, object.isPermanent);
+        fbb.addBool(5, object.shouldRemind);
+        fbb.addOffset(6, reminderMessageOffset);
+        fbb.addOffset(7, warningMessageOffset);
+        fbb.addInt64(9, object.startDate?.millisecondsSinceEpoch);
+        fbb.addInt64(10, object.endDate?.millisecondsSinceEpoch);
+        fbb.addOffset(11, dbTypeOffset);
+        fbb.addOffset(12, dbDoseOffset);
+        fbb.addOffset(13, dbFrequencyOffset);
+        fbb.addOffset(14, dbStreakOffset);
+        fbb.addBool(15, object.isDeleted);
+        fbb.addBool(16, object.isSynced);
+        fbb.addInt64(17, object.updatedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(19, object.createdAt?.millisecondsSinceEpoch);
+        fbb.addOffset(20, uidOffset);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final startDateValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          22,
+        );
+        final endDateValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          24,
+        );
+        final updatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          38,
+        );
+        final createdAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          42,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final nameParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 6, '');
+        final uidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 44, '');
+        final descriptionParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 8);
+        final durationDaysParam = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          10,
+        );
+        final isPermanentParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          12,
+          false,
+        );
+        final startDateParam = startDateValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(startDateValue);
+        final endDateParam = endDateValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(endDateValue);
+        final shouldRemindParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          14,
+          false,
+        );
+        final reminderMessageParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 16);
+        final warningMessageParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 18);
+        final isDeletedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          34,
+          false,
+        );
+        final isSyncedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          36,
+          false,
+        );
+        final updatedAtParam = updatedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
+        final createdAtParam = createdAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
+        final object =
+            Medication(
+                id: idParam,
+                name: nameParam,
+                uid: uidParam,
+                description: descriptionParam,
+                durationDays: durationDaysParam,
+                isPermanent: isPermanentParam,
+                startDate: startDateParam,
+                endDate: endDateParam,
+                shouldRemind: shouldRemindParam,
+                reminderMessage: reminderMessageParam,
+                warningMessage: warningMessageParam,
+                isDeleted: isDeletedParam,
+                isSynced: isSyncedParam,
+                updatedAt: updatedAtParam,
+                createdAt: createdAtParam,
+              )
+              ..dbType = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 26)
+              ..dbDose = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 28)
+              ..dbFrequency = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 30)
+              ..dbStreak = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 32);
+        obx_int.InternalToManyAccess.setRelInfo<Medication>(
+          object.activityRecord,
+          store,
+          obx_int.RelInfo<Medication>.toMany(3, object.id),
+        );
+        return object;
+      },
+    ),
     AppUser: obx_int.EntityDefinition<AppUser>(
-        model: _entities[4],
-        toOneRelations: (AppUser object) => [object.profile],
-        toManyRelations: (AppUser object) => {},
-        getId: (AppUser object) => object.id,
-        setId: (AppUser object, int id) {
-          object.id = id;
-        },
-        objectToFB: (AppUser object, fb.Builder fbb) {
-          final uidOffset = fbb.writeString(object.uid);
-          final emailOffset = fbb.writeString(object.email);
-          final photoUrlOffset = object.photoUrl == null
-              ? null
-              : fbb.writeString(object.photoUrl!);
-          final dbPreferencesOffset = object.dbPreferences == null
-              ? null
-              : fbb.writeString(object.dbPreferences!);
-          fbb.startTable(13);
-          fbb.addInt64(0, object.id);
-          fbb.addOffset(1, uidOffset);
-          fbb.addOffset(2, emailOffset);
-          fbb.addOffset(3, photoUrlOffset);
-          fbb.addBool(4, object.isAnonymous);
-          fbb.addBool(5, object.isEmailVerified);
-          fbb.addBool(6, object.isPhoneVerified);
-          fbb.addInt64(7, object.profile.targetId);
-          fbb.addOffset(8, dbPreferencesOffset);
-          fbb.addBool(9, object.isDeleted);
-          fbb.addBool(10, object.isSynced);
-          fbb.addInt64(11, object.updatedAt?.millisecondsSinceEpoch);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final updatedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 26);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final emailParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 8, '');
-          final uidParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 6, '');
-          final isAnonymousParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 12, false);
-          final isEmailVerifiedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 14, false);
-          final isPhoneVerifiedParam =
-              const fb.BoolReader().vTableGetNullable(buffer, rootOffset, 16);
-          final photoUrlParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 10);
-          final isDeletedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 22, false);
-          final isSyncedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 24, false);
-          final updatedAtParam = updatedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
-          final object = AppUser(
-              id: idParam,
-              email: emailParam,
-              uid: uidParam,
-              isAnonymous: isAnonymousParam,
-              isEmailVerified: isEmailVerifiedParam,
-              isPhoneVerified: isPhoneVerifiedParam,
-              photoUrl: photoUrlParam,
-              isDeleted: isDeletedParam,
-              isSynced: isSyncedParam,
-              updatedAt: updatedAtParam)
-            ..dbPreferences = const fb.StringReader(asciiOptimization: true)
-                .vTableGetNullable(buffer, rootOffset, 20);
-          object.profile.targetId =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 18, 0);
-          object.profile.attach(store);
-          return object;
-        }),
+      model: _entities[4],
+      toOneRelations: (AppUser object) => [object.profile],
+      toManyRelations: (AppUser object) => {},
+      getId: (AppUser object) => object.id,
+      setId: (AppUser object, int id) {
+        object.id = id;
+      },
+      objectToFB: (AppUser object, fb.Builder fbb) {
+        final uidOffset = fbb.writeString(object.uid);
+        final emailOffset = fbb.writeString(object.email);
+        final photoUrlOffset = object.photoUrl == null
+            ? null
+            : fbb.writeString(object.photoUrl!);
+        final dbPreferencesOffset = object.dbPreferences == null
+            ? null
+            : fbb.writeString(object.dbPreferences!);
+        fbb.startTable(13);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, uidOffset);
+        fbb.addOffset(2, emailOffset);
+        fbb.addOffset(3, photoUrlOffset);
+        fbb.addBool(4, object.isAnonymous);
+        fbb.addBool(5, object.isEmailVerified);
+        fbb.addBool(6, object.isPhoneVerified);
+        fbb.addInt64(7, object.profile.targetId);
+        fbb.addOffset(8, dbPreferencesOffset);
+        fbb.addBool(9, object.isDeleted);
+        fbb.addBool(10, object.isSynced);
+        fbb.addInt64(11, object.updatedAt?.millisecondsSinceEpoch);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final updatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          26,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final emailParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 8, '');
+        final uidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 6, '');
+        final isAnonymousParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          12,
+          false,
+        );
+        final isEmailVerifiedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          14,
+          false,
+        );
+        final isPhoneVerifiedParam = const fb.BoolReader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          16,
+        );
+        final photoUrlParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 10);
+        final isDeletedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          22,
+          false,
+        );
+        final isSyncedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          24,
+          false,
+        );
+        final updatedAtParam = updatedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
+        final object =
+            AppUser(
+                id: idParam,
+                email: emailParam,
+                uid: uidParam,
+                isAnonymous: isAnonymousParam,
+                isEmailVerified: isEmailVerifiedParam,
+                isPhoneVerified: isPhoneVerifiedParam,
+                photoUrl: photoUrlParam,
+                isDeleted: isDeletedParam,
+                isSynced: isSyncedParam,
+                updatedAt: updatedAtParam,
+              )
+              ..dbPreferences = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGetNullable(buffer, rootOffset, 20);
+        object.profile.targetId = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          18,
+          0,
+        );
+        object.profile.attach(store);
+        return object;
+      },
+    ),
     MedActivityRecord: obx_int.EntityDefinition<MedActivityRecord>(
-        model: _entities[5],
-        toOneRelations: (MedActivityRecord object) => [],
-        toManyRelations: (MedActivityRecord object) => {},
-        getId: (MedActivityRecord object) => object.id,
-        setId: (MedActivityRecord object, int id) {
-          object.id = id;
-        },
-        objectToFB: (MedActivityRecord object, fb.Builder fbb) {
-          final dbTypeOffset = fbb.writeString(object.dbType);
-          final dbStatusOffset = fbb.writeString(object.dbStatus);
-          final dbActivityDetailsOffset =
-              fbb.writeString(object.dbActivityDetails);
-          final noteOffset =
-              object.note == null ? null : fbb.writeString(object.note!);
-          final skipReasonOffset = object.skipReason == null
-              ? null
-              : fbb.writeString(object.skipReason!);
-          final parentIdOffset = fbb.writeString(object.parentId);
-          fbb.startTable(11);
-          fbb.addInt64(0, object.id);
-          fbb.addOffset(2, dbTypeOffset);
-          fbb.addOffset(3, dbStatusOffset);
-          fbb.addOffset(4, dbActivityDetailsOffset);
-          fbb.addInt64(5, object.completedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(6, object.date.millisecondsSinceEpoch);
-          fbb.addOffset(7, noteOffset);
-          fbb.addOffset(8, skipReasonOffset);
-          fbb.addOffset(9, parentIdOffset);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final completedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 14);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final dateParam = DateTime.fromMillisecondsSinceEpoch(
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 16, 0));
-          final parentIdParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 22, '');
-          final noteParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 18);
-          final skipReasonParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 20);
-          final completedAtParam = completedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(completedAtValue);
-          final object = MedActivityRecord(
-              id: idParam,
-              date: dateParam,
-              parentId: parentIdParam,
-              note: noteParam,
-              skipReason: skipReasonParam,
-              completedAt: completedAtParam)
-            ..dbType = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 8, '')
-            ..dbStatus = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 10, '')
-            ..dbActivityDetails = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 12, '');
+      model: _entities[5],
+      toOneRelations: (MedActivityRecord object) => [],
+      toManyRelations: (MedActivityRecord object) => {},
+      getId: (MedActivityRecord object) => object.id,
+      setId: (MedActivityRecord object, int id) {
+        object.id = id;
+      },
+      objectToFB: (MedActivityRecord object, fb.Builder fbb) {
+        final dbTypeOffset = fbb.writeString(object.dbType);
+        final dbStatusOffset = fbb.writeString(object.dbStatus);
+        final dbActivityDetailsOffset = fbb.writeString(
+          object.dbActivityDetails,
+        );
+        final noteOffset = object.note == null
+            ? null
+            : fbb.writeString(object.note!);
+        final skipReasonOffset = object.skipReason == null
+            ? null
+            : fbb.writeString(object.skipReason!);
+        final parentIdOffset = fbb.writeString(object.parentId);
+        fbb.startTable(11);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(2, dbTypeOffset);
+        fbb.addOffset(3, dbStatusOffset);
+        fbb.addOffset(4, dbActivityDetailsOffset);
+        fbb.addInt64(5, object.completedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(6, object.date.millisecondsSinceEpoch);
+        fbb.addOffset(7, noteOffset);
+        fbb.addOffset(8, skipReasonOffset);
+        fbb.addOffset(9, parentIdOffset);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final completedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          14,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final dateParam = DateTime.fromMillisecondsSinceEpoch(
+          const fb.Int64Reader().vTableGet(buffer, rootOffset, 16, 0),
+        );
+        final parentIdParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 22, '');
+        final noteParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 18);
+        final skipReasonParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 20);
+        final completedAtParam = completedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(completedAtValue);
+        final object =
+            MedActivityRecord(
+                id: idParam,
+                date: dateParam,
+                parentId: parentIdParam,
+                note: noteParam,
+                skipReason: skipReasonParam,
+                completedAt: completedAtParam,
+              )
+              ..dbType = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 8, '')
+              ..dbStatus = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 10, '')
+              ..dbActivityDetails = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 12, '');
 
-          return object;
-        }),
+        return object;
+      },
+    ),
     ScheduledDose: obx_int.EntityDefinition<ScheduledDose>(
-        model: _entities[6],
-        toOneRelations: (ScheduledDose object) => [],
-        toManyRelations: (ScheduledDose object) => {},
-        getId: (ScheduledDose object) => object.id,
-        setId: (ScheduledDose object, int id) {
-          object.id = id;
-        },
-        objectToFB: (ScheduledDose object, fb.Builder fbb) {
-          final noteOffset =
-              object.note == null ? null : fbb.writeString(object.note!);
-          final skipReasonOffset = object.skipReason == null
-              ? null
-              : fbb.writeString(object.skipReason!);
-          final parentIdOffset = fbb.writeString(object.parentId);
-          final dbActivityTypeOffset = fbb.writeString(object.dbActivityType);
-          final dbStatusOffset = fbb.writeString(object.dbStatus);
-          final dbActivityDetailsOffset =
-              fbb.writeString(object.dbActivityDetails);
-          final dbDoseOffset = fbb.writeString(object.dbDose);
-          final uidOffset = fbb.writeString(object.uid);
-          fbb.startTable(16);
-          fbb.addInt64(0, object.id);
-          fbb.addInt64(1, object.completedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(2, object.date.millisecondsSinceEpoch);
-          fbb.addOffset(3, noteOffset);
-          fbb.addOffset(4, skipReasonOffset);
-          fbb.addOffset(5, parentIdOffset);
-          fbb.addBool(6, object.isDeleted);
-          fbb.addBool(7, object.isSynced);
-          fbb.addInt64(8, object.updatedAt?.millisecondsSinceEpoch);
-          fbb.addInt64(9, object.createdAt?.millisecondsSinceEpoch);
-          fbb.addOffset(10, dbActivityTypeOffset);
-          fbb.addOffset(11, dbStatusOffset);
-          fbb.addOffset(12, dbActivityDetailsOffset);
-          fbb.addOffset(13, dbDoseOffset);
-          fbb.addOffset(14, uidOffset);
-          fbb.finish(fbb.endTable());
-          return object.id;
-        },
-        objectFromFB: (obx.Store store, ByteData fbData) {
-          final buffer = fb.BufferContext(fbData);
-          final rootOffset = buffer.derefObject(0);
-          final completedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 6);
-          final updatedAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 20);
-          final createdAtValue =
-              const fb.Int64Reader().vTableGetNullable(buffer, rootOffset, 22);
-          final idParam =
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 4, 0);
-          final uidParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 32, '');
-          final dateParam = DateTime.fromMillisecondsSinceEpoch(
-              const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0));
-          final parentIdParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGet(buffer, rootOffset, 14, '');
-          final completedAtParam = completedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(completedAtValue);
-          final noteParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 10);
-          final skipReasonParam = const fb.StringReader(asciiOptimization: true)
-              .vTableGetNullable(buffer, rootOffset, 12);
-          final isDeletedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 16, false);
-          final isSyncedParam =
-              const fb.BoolReader().vTableGet(buffer, rootOffset, 18, false);
-          final updatedAtParam = updatedAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
-          final createdAtParam = createdAtValue == null
-              ? null
-              : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
-          final object = ScheduledDose(
-              id: idParam,
-              uid: uidParam,
-              date: dateParam,
-              parentId: parentIdParam,
-              completedAt: completedAtParam,
-              note: noteParam,
-              skipReason: skipReasonParam,
-              isDeleted: isDeletedParam,
-              isSynced: isSyncedParam,
-              updatedAt: updatedAtParam,
-              createdAt: createdAtParam)
-            ..dbActivityType = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 24, '')
-            ..dbStatus = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 26, '')
-            ..dbActivityDetails = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 28, '')
-            ..dbDose = const fb.StringReader(asciiOptimization: true)
-                .vTableGet(buffer, rootOffset, 30, '');
+      model: _entities[6],
+      toOneRelations: (ScheduledDose object) => [],
+      toManyRelations: (ScheduledDose object) => {},
+      getId: (ScheduledDose object) => object.id,
+      setId: (ScheduledDose object, int id) {
+        object.id = id;
+      },
+      objectToFB: (ScheduledDose object, fb.Builder fbb) {
+        final noteOffset = object.note == null
+            ? null
+            : fbb.writeString(object.note!);
+        final skipReasonOffset = object.skipReason == null
+            ? null
+            : fbb.writeString(object.skipReason!);
+        final parentIdOffset = fbb.writeString(object.parentId);
+        final dbActivityTypeOffset = fbb.writeString(object.dbActivityType);
+        final dbStatusOffset = fbb.writeString(object.dbStatus);
+        final dbActivityDetailsOffset = fbb.writeString(
+          object.dbActivityDetails,
+        );
+        final dbDoseOffset = fbb.writeString(object.dbDose);
+        final uidOffset = fbb.writeString(object.uid);
+        fbb.startTable(16);
+        fbb.addInt64(0, object.id);
+        fbb.addInt64(1, object.completedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(2, object.date.millisecondsSinceEpoch);
+        fbb.addOffset(3, noteOffset);
+        fbb.addOffset(4, skipReasonOffset);
+        fbb.addOffset(5, parentIdOffset);
+        fbb.addBool(6, object.isDeleted);
+        fbb.addBool(7, object.isSynced);
+        fbb.addInt64(8, object.updatedAt?.millisecondsSinceEpoch);
+        fbb.addInt64(9, object.createdAt?.millisecondsSinceEpoch);
+        fbb.addOffset(10, dbActivityTypeOffset);
+        fbb.addOffset(11, dbStatusOffset);
+        fbb.addOffset(12, dbActivityDetailsOffset);
+        fbb.addOffset(13, dbDoseOffset);
+        fbb.addOffset(14, uidOffset);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final completedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          6,
+        );
+        final updatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          20,
+        );
+        final createdAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          22,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final uidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 32, '');
+        final dateParam = DateTime.fromMillisecondsSinceEpoch(
+          const fb.Int64Reader().vTableGet(buffer, rootOffset, 8, 0),
+        );
+        final parentIdParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 14, '');
+        final completedAtParam = completedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(completedAtValue);
+        final noteParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 10);
+        final skipReasonParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGetNullable(buffer, rootOffset, 12);
+        final isDeletedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          16,
+          false,
+        );
+        final isSyncedParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          18,
+          false,
+        );
+        final updatedAtParam = updatedAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(updatedAtValue);
+        final createdAtParam = createdAtValue == null
+            ? null
+            : DateTime.fromMillisecondsSinceEpoch(createdAtValue);
+        final object =
+            ScheduledDose(
+                id: idParam,
+                uid: uidParam,
+                date: dateParam,
+                parentId: parentIdParam,
+                completedAt: completedAtParam,
+                note: noteParam,
+                skipReason: skipReasonParam,
+                isDeleted: isDeletedParam,
+                isSynced: isSyncedParam,
+                updatedAt: updatedAtParam,
+                createdAt: createdAtParam,
+              )
+              ..dbActivityType = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 24, '')
+              ..dbStatus = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 26, '')
+              ..dbActivityDetails = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 28, '')
+              ..dbDose = const fb.StringReader(
+                asciiOptimization: true,
+              ).vTableGet(buffer, rootOffset, 30, '');
 
-          return object;
-        })
+        return object;
+      },
+    ),
   };
 
   return obx_int.ModelDefinition(model, bindings);
@@ -1310,381 +1635,471 @@ obx_int.ModelDefinition getObjectBoxModel() {
 /// [UserProfile] entity fields to define ObjectBox queries.
 class UserProfile_ {
   /// See [UserProfile.id].
-  static final id =
-      obx.QueryIntegerProperty<UserProfile>(_entities[0].properties[0]);
+  static final id = obx.QueryIntegerProperty<UserProfile>(
+    _entities[0].properties[0],
+  );
 
   /// See [UserProfile.uid].
-  static final uid =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[1]);
+  static final uid = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[1],
+  );
 
   /// See [UserProfile.name].
-  static final name =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[2]);
+  static final name = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[2],
+  );
 
   /// See [UserProfile.displayName].
-  static final displayName =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[3]);
+  static final displayName = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[3],
+  );
 
   /// See [UserProfile.age].
-  static final age =
-      obx.QueryIntegerProperty<UserProfile>(_entities[0].properties[4]);
+  static final age = obx.QueryIntegerProperty<UserProfile>(
+    _entities[0].properties[4],
+  );
 
   /// See [UserProfile.email].
-  static final email =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[5]);
+  static final email = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[5],
+  );
 
   /// See [UserProfile.photoUrl].
-  static final photoUrl =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[6]);
+  static final photoUrl = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[6],
+  );
 
   /// See [UserProfile.phone].
-  static final phone =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[7]);
+  static final phone = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[7],
+  );
 
   /// See [UserProfile.painSeverity].
-  static final painSeverity =
-      obx.QueryIntegerProperty<UserProfile>(_entities[0].properties[8]);
+  static final painSeverity = obx.QueryIntegerProperty<UserProfile>(
+    _entities[0].properties[8],
+  );
 
   /// See [UserProfile.crisisFrequency].
-  static final crisisFrequency =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[9]);
+  static final crisisFrequency = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[9],
+  );
 
   /// See [UserProfile.height].
-  static final height =
-      obx.QueryDoubleProperty<UserProfile>(_entities[0].properties[10]);
+  static final height = obx.QueryDoubleProperty<UserProfile>(
+    _entities[0].properties[10],
+  );
 
   /// See [UserProfile.weight].
-  static final weight =
-      obx.QueryDoubleProperty<UserProfile>(_entities[0].properties[11]);
+  static final weight = obx.QueryDoubleProperty<UserProfile>(
+    _entities[0].properties[11],
+  );
 
   /// See [UserProfile.bmi].
-  static final bmi =
-      obx.QueryDoubleProperty<UserProfile>(_entities[0].properties[12]);
+  static final bmi = obx.QueryDoubleProperty<UserProfile>(
+    _entities[0].properties[12],
+  );
 
   /// See [UserProfile.bloodGroup].
-  static final bloodGroup =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[13]);
+  static final bloodGroup = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[13],
+  );
 
   /// See [UserProfile.allergies].
-  static final allergies =
-      obx.QueryStringVectorProperty<UserProfile>(_entities[0].properties[14]);
+  static final allergies = obx.QueryStringVectorProperty<UserProfile>(
+    _entities[0].properties[14],
+  );
 
   /// See [UserProfile.medicalConditions].
-  static final medicalConditions =
-      obx.QueryStringVectorProperty<UserProfile>(_entities[0].properties[15]);
+  static final medicalConditions = obx.QueryStringVectorProperty<UserProfile>(
+    _entities[0].properties[15],
+  );
 
   /// See [UserProfile.dbGender].
-  static final dbGender =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[16]);
+  static final dbGender = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[16],
+  );
 
   /// See [UserProfile.dbGenotype].
-  static final dbGenotype =
-      obx.QueryStringProperty<UserProfile>(_entities[0].properties[17]);
+  static final dbGenotype = obx.QueryStringProperty<UserProfile>(
+    _entities[0].properties[17],
+  );
 
   /// See [UserProfile.isDeleted].
-  static final isDeleted =
-      obx.QueryBooleanProperty<UserProfile>(_entities[0].properties[18]);
+  static final isDeleted = obx.QueryBooleanProperty<UserProfile>(
+    _entities[0].properties[18],
+  );
 
   /// See [UserProfile.isSynced].
-  static final isSynced =
-      obx.QueryBooleanProperty<UserProfile>(_entities[0].properties[19]);
+  static final isSynced = obx.QueryBooleanProperty<UserProfile>(
+    _entities[0].properties[19],
+  );
 
   /// See [UserProfile.updatedAt].
-  static final updatedAt =
-      obx.QueryDateProperty<UserProfile>(_entities[0].properties[20]);
+  static final updatedAt = obx.QueryDateProperty<UserProfile>(
+    _entities[0].properties[20],
+  );
 
   /// See [UserProfile.createdAt].
-  static final createdAt =
-      obx.QueryDateProperty<UserProfile>(_entities[0].properties[21]);
+  static final createdAt = obx.QueryDateProperty<UserProfile>(
+    _entities[0].properties[21],
+  );
 }
 
 /// [WaterLog] entity fields to define ObjectBox queries.
 class WaterLog_ {
   /// See [WaterLog.id].
-  static final id =
-      obx.QueryIntegerProperty<WaterLog>(_entities[1].properties[0]);
+  static final id = obx.QueryIntegerProperty<WaterLog>(
+    _entities[1].properties[0],
+  );
 
   /// See [WaterLog.timestamp].
-  static final timestamp =
-      obx.QueryDateProperty<WaterLog>(_entities[1].properties[1]);
+  static final timestamp = obx.QueryDateProperty<WaterLog>(
+    _entities[1].properties[1],
+  );
 
   /// See [WaterLog.value].
-  static final value =
-      obx.QueryDoubleProperty<WaterLog>(_entities[1].properties[2]);
+  static final value = obx.QueryDoubleProperty<WaterLog>(
+    _entities[1].properties[2],
+  );
 
   /// See [WaterLog.dbUnit].
-  static final dbUnit =
-      obx.QueryStringProperty<WaterLog>(_entities[1].properties[3]);
+  static final dbUnit = obx.QueryStringProperty<WaterLog>(
+    _entities[1].properties[3],
+  );
 }
 
 /// [WaterPreferences] entity fields to define ObjectBox queries.
 class WaterPreferences_ {
   /// See [WaterPreferences.id].
-  static final id =
-      obx.QueryIntegerProperty<WaterPreferences>(_entities[2].properties[0]);
+  static final id = obx.QueryIntegerProperty<WaterPreferences>(
+    _entities[2].properties[0],
+  );
 
   /// See [WaterPreferences.defaultDailyGoal].
-  static final defaultDailyGoal =
-      obx.QueryDoubleProperty<WaterPreferences>(_entities[2].properties[1]);
+  static final defaultDailyGoal = obx.QueryDoubleProperty<WaterPreferences>(
+    _entities[2].properties[1],
+  );
 
   /// See [WaterPreferences.defaultLogValue].
-  static final defaultLogValue =
-      obx.QueryDoubleProperty<WaterPreferences>(_entities[2].properties[2]);
+  static final defaultLogValue = obx.QueryDoubleProperty<WaterPreferences>(
+    _entities[2].properties[2],
+  );
 
   /// See [WaterPreferences.dbUnit].
-  static final dbUnit =
-      obx.QueryStringProperty<WaterPreferences>(_entities[2].properties[3]);
+  static final dbUnit = obx.QueryStringProperty<WaterPreferences>(
+    _entities[2].properties[3],
+  );
 
   /// See [WaterPreferences.isDeleted].
-  static final isDeleted =
-      obx.QueryBooleanProperty<WaterPreferences>(_entities[2].properties[4]);
+  static final isDeleted = obx.QueryBooleanProperty<WaterPreferences>(
+    _entities[2].properties[4],
+  );
 
   /// See [WaterPreferences.isSynced].
-  static final isSynced =
-      obx.QueryBooleanProperty<WaterPreferences>(_entities[2].properties[5]);
+  static final isSynced = obx.QueryBooleanProperty<WaterPreferences>(
+    _entities[2].properties[5],
+  );
 
   /// See [WaterPreferences.updatedAt].
-  static final updatedAt =
-      obx.QueryDateProperty<WaterPreferences>(_entities[2].properties[6]);
+  static final updatedAt = obx.QueryDateProperty<WaterPreferences>(
+    _entities[2].properties[6],
+  );
 
   /// See [WaterPreferences.createdAt].
-  static final createdAt =
-      obx.QueryDateProperty<WaterPreferences>(_entities[2].properties[7]);
+  static final createdAt = obx.QueryDateProperty<WaterPreferences>(
+    _entities[2].properties[7],
+  );
 }
 
 /// [Medication] entity fields to define ObjectBox queries.
 class Medication_ {
   /// See [Medication.id].
-  static final id =
-      obx.QueryIntegerProperty<Medication>(_entities[3].properties[0]);
+  static final id = obx.QueryIntegerProperty<Medication>(
+    _entities[3].properties[0],
+  );
 
   /// See [Medication.name].
-  static final name =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[1]);
+  static final name = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[1],
+  );
 
   /// See [Medication.description].
-  static final description =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[2]);
+  static final description = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[2],
+  );
 
   /// See [Medication.durationDays].
-  static final durationDays =
-      obx.QueryIntegerProperty<Medication>(_entities[3].properties[3]);
+  static final durationDays = obx.QueryIntegerProperty<Medication>(
+    _entities[3].properties[3],
+  );
 
   /// See [Medication.isPermanent].
-  static final isPermanent =
-      obx.QueryBooleanProperty<Medication>(_entities[3].properties[4]);
+  static final isPermanent = obx.QueryBooleanProperty<Medication>(
+    _entities[3].properties[4],
+  );
 
   /// See [Medication.shouldRemind].
-  static final shouldRemind =
-      obx.QueryBooleanProperty<Medication>(_entities[3].properties[5]);
+  static final shouldRemind = obx.QueryBooleanProperty<Medication>(
+    _entities[3].properties[5],
+  );
 
   /// See [Medication.reminderMessage].
-  static final reminderMessage =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[6]);
+  static final reminderMessage = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[6],
+  );
 
   /// See [Medication.warningMessage].
-  static final warningMessage =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[7]);
+  static final warningMessage = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[7],
+  );
 
   /// See [Medication.startDate].
-  static final startDate =
-      obx.QueryDateProperty<Medication>(_entities[3].properties[8]);
+  static final startDate = obx.QueryDateProperty<Medication>(
+    _entities[3].properties[8],
+  );
 
   /// See [Medication.endDate].
-  static final endDate =
-      obx.QueryDateProperty<Medication>(_entities[3].properties[9]);
+  static final endDate = obx.QueryDateProperty<Medication>(
+    _entities[3].properties[9],
+  );
 
   /// See [Medication.dbType].
-  static final dbType =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[10]);
+  static final dbType = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[10],
+  );
 
   /// See [Medication.dbDose].
-  static final dbDose =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[11]);
+  static final dbDose = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[11],
+  );
 
   /// See [Medication.dbFrequency].
-  static final dbFrequency =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[12]);
+  static final dbFrequency = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[12],
+  );
 
   /// See [Medication.dbStreak].
-  static final dbStreak =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[13]);
+  static final dbStreak = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[13],
+  );
 
   /// See [Medication.isDeleted].
-  static final isDeleted =
-      obx.QueryBooleanProperty<Medication>(_entities[3].properties[14]);
+  static final isDeleted = obx.QueryBooleanProperty<Medication>(
+    _entities[3].properties[14],
+  );
 
   /// See [Medication.isSynced].
-  static final isSynced =
-      obx.QueryBooleanProperty<Medication>(_entities[3].properties[15]);
+  static final isSynced = obx.QueryBooleanProperty<Medication>(
+    _entities[3].properties[15],
+  );
 
   /// See [Medication.updatedAt].
-  static final updatedAt =
-      obx.QueryDateProperty<Medication>(_entities[3].properties[16]);
+  static final updatedAt = obx.QueryDateProperty<Medication>(
+    _entities[3].properties[16],
+  );
 
   /// See [Medication.createdAt].
-  static final createdAt =
-      obx.QueryDateProperty<Medication>(_entities[3].properties[17]);
+  static final createdAt = obx.QueryDateProperty<Medication>(
+    _entities[3].properties[17],
+  );
 
   /// See [Medication.uid].
-  static final uid =
-      obx.QueryStringProperty<Medication>(_entities[3].properties[18]);
+  static final uid = obx.QueryStringProperty<Medication>(
+    _entities[3].properties[18],
+  );
 
   /// see [Medication.activityRecord]
   static final activityRecord =
       obx.QueryRelationToMany<Medication, MedActivityRecord>(
-          _entities[3].relations[0]);
+        _entities[3].relations[0],
+      );
 }
 
 /// [AppUser] entity fields to define ObjectBox queries.
 class AppUser_ {
   /// See [AppUser.id].
-  static final id =
-      obx.QueryIntegerProperty<AppUser>(_entities[4].properties[0]);
+  static final id = obx.QueryIntegerProperty<AppUser>(
+    _entities[4].properties[0],
+  );
 
   /// See [AppUser.uid].
-  static final uid =
-      obx.QueryStringProperty<AppUser>(_entities[4].properties[1]);
+  static final uid = obx.QueryStringProperty<AppUser>(
+    _entities[4].properties[1],
+  );
 
   /// See [AppUser.email].
-  static final email =
-      obx.QueryStringProperty<AppUser>(_entities[4].properties[2]);
+  static final email = obx.QueryStringProperty<AppUser>(
+    _entities[4].properties[2],
+  );
 
   /// See [AppUser.photoUrl].
-  static final photoUrl =
-      obx.QueryStringProperty<AppUser>(_entities[4].properties[3]);
+  static final photoUrl = obx.QueryStringProperty<AppUser>(
+    _entities[4].properties[3],
+  );
 
   /// See [AppUser.isAnonymous].
-  static final isAnonymous =
-      obx.QueryBooleanProperty<AppUser>(_entities[4].properties[4]);
+  static final isAnonymous = obx.QueryBooleanProperty<AppUser>(
+    _entities[4].properties[4],
+  );
 
   /// See [AppUser.isEmailVerified].
-  static final isEmailVerified =
-      obx.QueryBooleanProperty<AppUser>(_entities[4].properties[5]);
+  static final isEmailVerified = obx.QueryBooleanProperty<AppUser>(
+    _entities[4].properties[5],
+  );
 
   /// See [AppUser.isPhoneVerified].
-  static final isPhoneVerified =
-      obx.QueryBooleanProperty<AppUser>(_entities[4].properties[6]);
+  static final isPhoneVerified = obx.QueryBooleanProperty<AppUser>(
+    _entities[4].properties[6],
+  );
 
   /// See [AppUser.profile].
-  static final profile =
-      obx.QueryRelationToOne<AppUser, UserProfile>(_entities[4].properties[7]);
+  static final profile = obx.QueryRelationToOne<AppUser, UserProfile>(
+    _entities[4].properties[7],
+  );
 
   /// See [AppUser.dbPreferences].
-  static final dbPreferences =
-      obx.QueryStringProperty<AppUser>(_entities[4].properties[8]);
+  static final dbPreferences = obx.QueryStringProperty<AppUser>(
+    _entities[4].properties[8],
+  );
 
   /// See [AppUser.isDeleted].
-  static final isDeleted =
-      obx.QueryBooleanProperty<AppUser>(_entities[4].properties[9]);
+  static final isDeleted = obx.QueryBooleanProperty<AppUser>(
+    _entities[4].properties[9],
+  );
 
   /// See [AppUser.isSynced].
-  static final isSynced =
-      obx.QueryBooleanProperty<AppUser>(_entities[4].properties[10]);
+  static final isSynced = obx.QueryBooleanProperty<AppUser>(
+    _entities[4].properties[10],
+  );
 
   /// See [AppUser.updatedAt].
-  static final updatedAt =
-      obx.QueryDateProperty<AppUser>(_entities[4].properties[11]);
+  static final updatedAt = obx.QueryDateProperty<AppUser>(
+    _entities[4].properties[11],
+  );
 }
 
 /// [MedActivityRecord] entity fields to define ObjectBox queries.
 class MedActivityRecord_ {
   /// See [MedActivityRecord.id].
-  static final id =
-      obx.QueryIntegerProperty<MedActivityRecord>(_entities[5].properties[0]);
+  static final id = obx.QueryIntegerProperty<MedActivityRecord>(
+    _entities[5].properties[0],
+  );
 
   /// See [MedActivityRecord.dbType].
-  static final dbType =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[1]);
+  static final dbType = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[1],
+  );
 
   /// See [MedActivityRecord.dbStatus].
-  static final dbStatus =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[2]);
+  static final dbStatus = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[2],
+  );
 
   /// See [MedActivityRecord.dbActivityDetails].
-  static final dbActivityDetails =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[3]);
+  static final dbActivityDetails = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[3],
+  );
 
   /// See [MedActivityRecord.completedAt].
-  static final completedAt =
-      obx.QueryDateProperty<MedActivityRecord>(_entities[5].properties[4]);
+  static final completedAt = obx.QueryDateProperty<MedActivityRecord>(
+    _entities[5].properties[4],
+  );
 
   /// See [MedActivityRecord.date].
-  static final date =
-      obx.QueryDateProperty<MedActivityRecord>(_entities[5].properties[5]);
+  static final date = obx.QueryDateProperty<MedActivityRecord>(
+    _entities[5].properties[5],
+  );
 
   /// See [MedActivityRecord.note].
-  static final note =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[6]);
+  static final note = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[6],
+  );
 
   /// See [MedActivityRecord.skipReason].
-  static final skipReason =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[7]);
+  static final skipReason = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[7],
+  );
 
   /// See [MedActivityRecord.parentId].
-  static final parentId =
-      obx.QueryStringProperty<MedActivityRecord>(_entities[5].properties[8]);
+  static final parentId = obx.QueryStringProperty<MedActivityRecord>(
+    _entities[5].properties[8],
+  );
 }
 
 /// [ScheduledDose] entity fields to define ObjectBox queries.
 class ScheduledDose_ {
   /// See [ScheduledDose.id].
-  static final id =
-      obx.QueryIntegerProperty<ScheduledDose>(_entities[6].properties[0]);
+  static final id = obx.QueryIntegerProperty<ScheduledDose>(
+    _entities[6].properties[0],
+  );
 
   /// See [ScheduledDose.completedAt].
-  static final completedAt =
-      obx.QueryDateProperty<ScheduledDose>(_entities[6].properties[1]);
+  static final completedAt = obx.QueryDateProperty<ScheduledDose>(
+    _entities[6].properties[1],
+  );
 
   /// See [ScheduledDose.date].
-  static final date =
-      obx.QueryDateProperty<ScheduledDose>(_entities[6].properties[2]);
+  static final date = obx.QueryDateProperty<ScheduledDose>(
+    _entities[6].properties[2],
+  );
 
   /// See [ScheduledDose.note].
-  static final note =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[3]);
+  static final note = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[3],
+  );
 
   /// See [ScheduledDose.skipReason].
-  static final skipReason =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[4]);
+  static final skipReason = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[4],
+  );
 
   /// See [ScheduledDose.parentId].
-  static final parentId =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[5]);
+  static final parentId = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[5],
+  );
 
   /// See [ScheduledDose.isDeleted].
-  static final isDeleted =
-      obx.QueryBooleanProperty<ScheduledDose>(_entities[6].properties[6]);
+  static final isDeleted = obx.QueryBooleanProperty<ScheduledDose>(
+    _entities[6].properties[6],
+  );
 
   /// See [ScheduledDose.isSynced].
-  static final isSynced =
-      obx.QueryBooleanProperty<ScheduledDose>(_entities[6].properties[7]);
+  static final isSynced = obx.QueryBooleanProperty<ScheduledDose>(
+    _entities[6].properties[7],
+  );
 
   /// See [ScheduledDose.updatedAt].
-  static final updatedAt =
-      obx.QueryDateProperty<ScheduledDose>(_entities[6].properties[8]);
+  static final updatedAt = obx.QueryDateProperty<ScheduledDose>(
+    _entities[6].properties[8],
+  );
 
   /// See [ScheduledDose.createdAt].
-  static final createdAt =
-      obx.QueryDateProperty<ScheduledDose>(_entities[6].properties[9]);
+  static final createdAt = obx.QueryDateProperty<ScheduledDose>(
+    _entities[6].properties[9],
+  );
 
   /// See [ScheduledDose.dbActivityType].
-  static final dbActivityType =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[10]);
+  static final dbActivityType = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[10],
+  );
 
   /// See [ScheduledDose.dbStatus].
-  static final dbStatus =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[11]);
+  static final dbStatus = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[11],
+  );
 
   /// See [ScheduledDose.dbActivityDetails].
-  static final dbActivityDetails =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[12]);
+  static final dbActivityDetails = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[12],
+  );
 
   /// See [ScheduledDose.dbDose].
-  static final dbDose =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[13]);
+  static final dbDose = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[13],
+  );
 
   /// See [ScheduledDose.uid].
-  static final uid =
-      obx.QueryStringProperty<ScheduledDose>(_entities[6].properties[14]);
+  static final uid = obx.QueryStringProperty<ScheduledDose>(
+    _entities[6].properties[14],
+  );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
+    version: "85.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -17,27 +17,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.54"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: f4ad0fea5f102201015c9aae9d93bc02f75dd9491529a8c21f88d17a8523d44c
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "7.6.0"
   analyzer_plugin:
     dependency: transitive
     description:
       name: analyzer_plugin
-      sha256: "9661b30b13a685efaee9f02e5d01ed9f2b423bd889d28a304d02d704aee69161"
+      sha256: a5ab7590c27b779f3d4de67f31c4109dbe13dd7339f86461a6f2a8ab2594d8ce
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.3"
+    version: "0.13.4"
   archive:
     dependency: transitive
     description:
@@ -74,10 +69,10 @@ packages:
     dependency: "direct dev"
     description:
       name: auto_route_generator
-      sha256: c9086eb07271e51b44071ad5cff34e889f3156710b964a308c2ab590769e79e6
+      sha256: c2e359d8932986d4d1bcad7a428143f81384ce10fef8d4aa5bc29e1f83766a46
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.3.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -178,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -290,42 +285,42 @@ packages:
     dependency: "direct dev"
     description:
       name: custom_lint
-      sha256: "3486c470bb93313a9417f926c7dd694a2e349220992d7b9d14534dc49c15bba9"
+      sha256: "9656925637516c5cf0f5da018b33df94025af2088fe09c8ae2ca54c53f2d9a84"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.6"
   custom_lint_builder:
     dependency: transitive
     description:
       name: custom_lint_builder
-      sha256: "42cdc41994eeeddab0d7a722c7093ec52bd0761921eeb2cbdbf33d192a234759"
+      sha256: "6cdc8e87e51baaaba9c43e283ed8d28e59a0c4732279df62f66f7b5984655414"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.6"
   custom_lint_core:
     dependency: transitive
     description:
       name: custom_lint_core
-      sha256: "02450c3e45e2a6e8b26c4d16687596ab3c4644dd5792e3313aa9ceba5a49b7f5"
+      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.5"
   custom_lint_visitor:
     dependency: transitive
     description:
       name: custom_lint_visitor
-      sha256: bfe9b7a09c4775a587b58d10ebb871d4fe618237639b1e84d5ec62d7dfef25f9
+      sha256: "4a86a0d8415a91fbb8298d6ef03e9034dc8e323a599ddc4120a0e36c433983a2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+6.11.0"
+    version: "1.0.0+7.7.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7306ab8a2359a48d22310ad823521d723acfed60ee1f7e37388e8986853b6820"
+      sha256: "8a0e5fba27e8ee025d2ffb4ee820b4e6e2cf5e4246a6b1a477eb66866947e0bb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.8"
+    version: "3.1.1"
   dartx:
     dependency: transitive
     description:
@@ -354,10 +349,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -633,10 +628,10 @@ packages:
     dependency: transitive
     description:
       name: freezed_annotation
-      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "3.1.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -777,10 +772,10 @@ packages:
     dependency: "direct dev"
     description:
       name: icon_font_generator
-      sha256: e677646989862d9f221f4d2914bc4518c0775667d4291502a7e9b041d502d278
+      sha256: "100a4f5093f10cd83ae5ee3f1ca862c90f536436136dadc2bbc2a96aa391a08e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "3.2.0"
   image_size_getter:
     dependency: transitive
     description:
@@ -833,26 +828,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -861,14 +856,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
-  logger:
-    dependency: transitive
-    description:
-      name: logger
-      sha256: "7ad7215c15420a102ec687bb320a7312afd449bac63bfb1c60d9787c27b9767f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   logging:
     dependency: transitive
     description:
@@ -877,30 +864,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   mesh_gradient:
     dependency: "direct main"
     description:
@@ -913,10 +892,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1137,10 +1116,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: c6b8222b2b483cb87ae77ad147d6408f400c64f060df7a225b127f4afef4f8c8
+      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.8"
+    version: "0.5.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
@@ -1153,18 +1132,18 @@ packages:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "63546d70952015f0981361636bf8f356d9cfd9d7f6f0815e3c07789a41233188"
+      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.3"
+    version: "2.6.5"
   riverpod_lint:
     dependency: "direct dev"
     description:
       name: riverpod_lint
-      sha256: "83e4caa337a9840469b7b9bd8c2351ce85abad80f570d84146911b32086fbd99"
+      sha256: "89a52b7334210dbff8605c3edf26cfe69b15062beed5cbfeff2c3812c33c9e35"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.3"
+    version: "2.6.5"
   rxdart:
     dependency: transitive
     description:
@@ -1198,10 +1177,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: "35c8150ece9e8c8d263337a265153c3329667640850b9304861faea59fc98f6b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.0"
   source_span:
     dependency: transitive
     description:
@@ -1326,10 +1305,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.11"
   time:
     dependency: transitive
     description:
@@ -1462,10 +1441,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -1531,5 +1510,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  carp_serializable:
+    dependency: transitive
+    description:
+      name: carp_serializable
+      sha256: f039f8ea22e9437aef13fe7e9743c3761c76d401288dcb702eadd273c3e4dcef
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
@@ -337,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: "98f28b42168cc509abc92f88518882fd58061ea372d7999aecc424345c7bff6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.5.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   equatable:
     dependency: "direct main"
     description:
@@ -728,6 +752,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  health:
+    dependency: "direct main"
+    description:
+      name: health
+      sha256: "0432c4e5c5348164adff57e78ca3191c88f0cdf7c2b0d72b6785a6af965177ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.2.1"
   hotreloader:
     dependency: transitive
     description:
@@ -1485,6 +1517,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "6f1b564492d0147b330dd794fee8f512cec4977957f310f9951b5f9d83618dae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1511,4 +1559,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ dev_dependencies:
 
   flutter_lints: ^5.0.0
   build_runner: ^2.4.14
-  icon_font_generator: ^4.0.0
+  icon_font_generator: ^3.2.0
   mocktail: ^1.0.3
   custom_lint: ^0.7.0
   riverpod_lint: ^2.6.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   timezone: ^0.10.0
   flutter_timezone: ^4.1.0
   url_launcher: ^6.3.1
+  health: ^12.0.0
 
 
 


### PR DESCRIPTION
## Summary

Adds a first **draft** implementation of Health Connect (Android) / HealthKit (iOS) integration. It reads three metrics **read-only** — steps, heart rate, and blood oxygen (SpO2) — and surfaces them on a home dashboard card and a dedicated health detail screen.

This is an early cut: the plumbing, permission flow, and UI are in place, but there's plenty still to do (see below). Merging now to establish the foundation and unblock further work on `main`.

## What's included

- **New `health_connect` feature** following the standard feature-first layout (service → repository → notifiers → screen):
  - `HealthConnectService` wraps the `health` package (configure-once, availability check, permission check/request, per-metric reads). Normalizes SpO2 to a 0–100% across Health Connect / HealthKit.
  - `HealthRepository` returns `FutureEither`, maps platform booleans onto a `HealthPermissionStatus` enum, and aggregates reads into a `HealthSummary`.
  - Two `keepAlive` notifiers — permission and summary — split by lifecycle.
  - `HealthScreen` at `/health`, branching UI on permission state.
- **Home integration:** `HealthSummaryCard` dashboard tile; home screen checks permissions on load and fetches the summary (unawaited) only when granted.
- **Android setup:**
  - Health Connect read permissions + permission-rationale handlers in the manifest.
  - `MainActivity` now extends `FlutterFragmentActivity` (required for the health plugin's permission launcher) — fixes the "permission launcher not found" / `HealthPermissionStatus.denied` error.
- **Dependency:** adds `health: ^12.0.0`.

> Note: this branch also carries the earlier `chore:` package upgrade (riverpod pinned to v2) and the resulting regenerated bindings (objectbox, assets, provider `.g.dart`), plus a small null-guard fix in `WaterLogNotifier.calculateTotalFromLogs`.

## Known limitations / TODO

- **Android-first** — iOS/HealthKit path is wired but unverified.
- Data is **in-memory only** — no Firebase sync, no ObjectBox persistence.
- Limited to 3 metrics; no historical/range queries beyond the last 24h.
- No background refresh, caching, or pull-to-refresh.
- No tests yet for the service/repository/notifiers.
- Permission denial UX is minimal (no "open settings" deep link).

## Testing

- Requires the Health Connect app installed and some sample data on-device.
- Manual: grant permission from the health screen → steps / heart rate / SpO2 populate on the card and detail screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
